### PR TITLE
[travis] Add Travis initial support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+compiler:
+  - clang
+  - gcc
+script: "./.travis/build"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libtinyxml-dev
+matrix:
+  allow_failures:
+    - compiler: clang

--- a/.travis/build
+++ b/.travis/build
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -ev
+
+# Directories.
+root_dir=`pwd`
+build_dir="$root_dir/_travis/build"
+install_dir="$root_dir/_travis/install"
+console_bridge_dir="$build_dir/console_bridge"
+urdfdom_headers_dir="$build_dir/urdfdom_headers"
+
+# Shortcuts.
+git_clone="git clone --quiet --recursive"
+
+# Create layout.
+rm -rf "$build_dir" "$install_dir"
+mkdir -p "$build_dir"
+mkdir -p "$install_dir"
+
+# Setup environment variables.
+export LD_LIBRARY_PATH="$install_dir/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# Retrieve console_bridge
+echo "--> Compiling console_bridge"
+cd "$build_dir"
+$git_clone "git://github.com/ros/console_bridge.git"
+cd "$console_bridge_dir"
+cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
+make install
+
+# Retrieve urdfdom_headers
+echo "--> Compiling urdfdom_headers"
+cd "$build_dir"
+$git_clone "git://github.com/ros/urdfdom_headers.git"
+cd "$urdfdom_headers_dir"
+cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
+make install
+
+# Compile
+echo "--> Compiling urdfdom"
+cd "$root_dir"
+cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
+make
+#make check
+make install


### PR DESCRIPTION
Dear all,
here is a commit which adds two files in order to add travis-ci.org support to urdfdom project.

It compiles each commit with both clang and gcc.

One interest is that clang provides sometimes interesting warnings, such as the ones (control may reach end of non-void function [-Wreturn-type]) found in the build I did:
https://travis-ci.org/thomas-moulard/urdfdom/jobs/10882198

I think compared to your buildfarm, the main interest is the direct integration with pull requests and the ability for people like me who fork your repositories to have some feedback on the project status _before_ sending it back to you.

Of course, the goal is after to write a small test suite so that we can validate that different models are parsed correctly (and eventually provide the same result in both C++ and Python).

For more information: http://about.travis-ci.org/docs/user/getting-started/
