### PR TITLE
Sync soversion to current ABI version

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -2,19 +2,19 @@ include_directories(include)
 
 add_library(urdfdom_world SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
 target_link_libraries(urdfdom_world ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(urdfdom_world PROPERTIES SOVERSION 0.2)
+set_target_properties(urdfdom_world PROPERTIES SOVERSION 0.3)
 
 add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
 target_link_libraries(urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(urdfdom_model PROPERTIES SOVERSION 0.2)
+set_target_properties(urdfdom_model PROPERTIES SOVERSION 0.3)
 
 add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
 target_link_libraries(urdfdom_sensor urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(urdfdom_sensor PROPERTIES SOVERSION 0.2)
+set_target_properties(urdfdom_sensor PROPERTIES SOVERSION 0.3)
 
 add_library(urdfdom_model_state SHARED src/urdf_model_state.cpp src/twist.cpp)
 target_link_libraries(urdfdom_model_state ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(urdfdom_model_state PROPERTIES SOVERSION 0.2)
+set_target_properties(urdfdom_model_state PROPERTIES SOVERSION 0.3)
 
 # --------------------------------
 


### PR DESCRIPTION
The package version (and the ABI version) has changed to 0.3.0 but the SOVERSION is still point to 0.2.
