### PR TITLE
urdf_parser_py: Add default values for JointLimit.lower and .upper

### DIFF
--- a/urdf_parser_py/src/urdf_parser_py/urdf.py
+++ b/urdf_parser_py/src/urdf_parser_py/urdf.py
@@ -237,8 +237,8 @@ class JointLimit(xmlr.Object):
 
 xmlr.reflect(JointLimit, params = [
 	xmlr.Attribute('effort', float),
-	xmlr.Attribute('lower', float),
-	xmlr.Attribute('upper', float),
+	xmlr.Attribute('lower', float, required=False, default=0.),
+	xmlr.Attribute('upper', float, required=False, default=0.),
 	xmlr.Attribute('velocity', float)
 	])
 


### PR DESCRIPTION
Following Issue #36, this adds default values for <joint><limit upper="..." lower="...></joint> according to http://wiki.ros.org/urdf/XML/joint.
