### PR TITLE
urdf_parser_py.xml_reflection : python 3 compatibility

### DIFF
--- a/urdf_parser_py/src/urdf_parser_py/xml_reflection/core.py
+++ b/urdf_parser_py/src/urdf_parser_py/xml_reflection/core.py
@@ -211,7 +211,7 @@ class DuckTypedFactory(ValueType):
 		for value_type in self.type_order:
 			try:
 				return value_type.from_xml(node)
-			except Exception, e:
+			except Exception as e:
 				error_set.append((value_type, e))
 		# Should have returned, we encountered errors
 		out = "Could not perform duck-typed parsing."


### PR DESCRIPTION
Substitute `Exception, e` with `Exception as e`. This ensure compatibility with Python 3+ and Python 2.6, 2.7 . 
Check https://docs.python.org/3/howto/pyporting.html#capturing-the-currently-raised-exception for more info.
