### PR TITLE
Fixes from sdformat

### DIFF
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -168,7 +168,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
   {
     y.length = boost::lexical_cast<double>(c->Attribute("length"));
   }
-  catch (boost::bad_lexical_cast &e)
+  catch (boost::bad_lexical_cast &/*e*/)
   {
     std::stringstream stm;
     stm << "length [" << c->Attribute("length") << "] is not a valid float";
@@ -180,7 +180,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
   {
     y.radius = boost::lexical_cast<double>(c->Attribute("radius"));
   }
-  catch (boost::bad_lexical_cast &e)
+  catch (boost::bad_lexical_cast &/*e*/)
   {
     std::stringstream stm;
     stm << "radius [" << c->Attribute("radius") << "] is not a valid float";
@@ -298,7 +298,7 @@ bool parseInertial(Inertial &i, TiXmlElement *config)
   {
     i.mass = boost::lexical_cast<double>(mass_xml->Attribute("value"));
   }
-  catch (boost::bad_lexical_cast &e)
+  catch (boost::bad_lexical_cast &/*e*/)
   {
     std::stringstream stm;
     stm << "Inertial: mass [" << mass_xml->Attribute("value")
@@ -329,7 +329,7 @@ bool parseInertial(Inertial &i, TiXmlElement *config)
     i.iyz  = boost::lexical_cast<double>(inertia_xml->Attribute("iyz"));
     i.izz  = boost::lexical_cast<double>(inertia_xml->Attribute("izz"));
   }
-  catch (boost::bad_lexical_cast &e)
+  catch (boost::bad_lexical_cast &/*e*/)
   {
     std::stringstream stm;
     stm << "Inertial: one of the inertia elements is not a valid double:"

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -480,6 +480,8 @@ bool parseLink(Link &link, TiXmlElement* config)
   // Assign the first collision to the .collision ptr, if it exists
   if (!link.collision_array.empty())
     link.collision = link.collision_array[0];
+
+  return true;
 }
 
 /* exports */

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -114,7 +114,7 @@ boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
         logDebug("urdfdom: successfully added a new material '%s'", material->name.c_str());
       }
     }
-    catch (ParseError &e) {
+    catch (ParseError &/*e*/) {
       logError("material xml is not initialized correctly");
       material.reset();
       model.reset();
@@ -170,7 +170,7 @@ boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
         logDebug("urdfdom: successfully added a new link '%s'", link->name.c_str());
       }
     }
-    catch (ParseError &e) {
+    catch (ParseError &/*e*/) {
       logError("link xml is not initialized correctly");
       model.reset();
       return model;

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -97,7 +97,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
           try {
             joint_state->position.push_back(boost::lexical_cast<double>(pieces[i].c_str()));
           }
-          catch (boost::bad_lexical_cast &e) {
+          catch (boost::bad_lexical_cast &/*e*/) {
             throw ParseError("position element ("+ pieces[i] +") is not a valid float");
           }
         }
@@ -116,7 +116,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
           try {
             joint_state->velocity.push_back(boost::lexical_cast<double>(pieces[i].c_str()));
           }
-          catch (boost::bad_lexical_cast &e) {
+          catch (boost::bad_lexical_cast &/*e*/) {
             throw ParseError("velocity element ("+ pieces[i] +") is not a valid float");
           }
         }
@@ -135,7 +135,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
           try {
             joint_state->effort.push_back(boost::lexical_cast<double>(pieces[i].c_str()));
           }
-          catch (boost::bad_lexical_cast &e) {
+          catch (boost::bad_lexical_cast &/*e*/) {
             throw ParseError("effort element ("+ pieces[i] +") is not a valid float");
           }
         }

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -145,7 +145,8 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
     // add to vector
     ms.joint_states.push_back(joint_state);
   }
-};
+  return false;
+}
 
 
 

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -292,6 +292,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
     }
   }
+  return false;
 }
 
 boost::shared_ptr<VisualSensor> parseVisualSensor(TiXmlElement *g)

--- a/urdf_parser/src/world.cpp
+++ b/urdf_parser/src/world.cpp
@@ -47,7 +47,7 @@
 
 namespace urdf{
 
-bool parseWorld(World &world, TiXmlElement* config)
+bool parseWorld(World &/*world*/, TiXmlElement* /*config*/)
 {
 
   // to be implemented


### PR DESCRIPTION
Make sure functions have something to return, and reduce warnings about unused catch variables.

See also https://github.com/ros/urdfdom_headers/pull/10

@nkoenig