### PR TITLE
Enable to build static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ if (HAS_VISIBILITY)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 endif()
 
+# Using dynamic linking by default
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+# If building static libraries, set URDFDOM_STATIC definition for symbol
+# visibility settings.
+if (NOT BUILD_SHARED_LIBS)
+  add_definitions(-DURDFDOM_STATIC)
+endif()
+
 # This shouldn't be necessary, but there has been trouble
 # with MSVC being set off, but MSVCXX ON.
 if(MSVC OR MSVC90 OR MSVC10)

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -1,18 +1,18 @@
 include_directories(include)
 
-add_library(urdfdom_world SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
+add_library(urdfdom_world src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
 target_link_libraries(urdfdom_world ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(urdfdom_world PROPERTIES SOVERSION 0.3)
 
-add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
+add_library(urdfdom_model src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
 target_link_libraries(urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(urdfdom_model PROPERTIES SOVERSION 0.3)
 
-add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
+add_library(urdfdom_sensor src/urdf_sensor.cpp)
 target_link_libraries(urdfdom_sensor urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(urdfdom_sensor PROPERTIES SOVERSION 0.3)
 
-add_library(urdfdom_model_state SHARED src/urdf_model_state.cpp src/twist.cpp)
+add_library(urdfdom_model_state src/urdf_model_state.cpp src/twist.cpp)
 target_link_libraries(urdfdom_model_state ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(urdfdom_model_state PROPERTIES SOVERSION 0.3)
 


### PR DESCRIPTION
This PR enables urdfdom to build static libraries by:
  * adding shared/static build option
  * adding URDFDOM_STATIC definition for static build
  * removing explicit build type specification from `add_library(~)`

This does not change the default build behavior (i.e., shared build) when the build type is not specified.
