### PR TITLE
Use new pointer typedefs, bump to 0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 project (urdfdom CXX C)
 
 set (URDF_MAJOR_VERSION 0)
-set (URDF_MINOR_VERSION 3)
+set (URDF_MINOR_VERSION 4)
 set (URDF_PATCH_VERSION 0)
 
 set (URDF_VERSION ${URDF_MAJOR_VERSION}.${URDF_MINOR_VERSION}.${URDF_PATCH_VERSION})
@@ -39,7 +39,7 @@ include_directories(${tinyxml_include_dirs})
 link_directories(${tinyxml_library_dirs})
 add_definitions(${tinyxml_cflags})
 
-find_package(urdfdom_headers REQUIRED)
+find_package(urdfdom_headers 0.4 REQUIRED)
 include_directories(SYSTEM ${urdfdom_headers_INCLUDE_DIRS})
 
 find_package(console_bridge REQUIRED)

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -40,7 +40,6 @@
 #include <string>
 #include <map>
 #include <tinyxml.h>
-#include <boost/function.hpp>
 #include <urdf_model/model.h>
 #include <urdf_model/color.h>
 #include <urdf_world/types.h>

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -43,6 +43,7 @@
 #include <boost/function.hpp>
 #include <urdf_model/model.h>
 #include <urdf_model/color.h>
+#include <urdf_world/types.h>
 
 #include "exportdecl.h"
 
@@ -58,9 +59,9 @@ URDFDOM_DLLAPI std::string values2str(double d);
 
 namespace urdf{
 
-  URDFDOM_DLLAPI boost::shared_ptr<ModelInterface> parseURDF(const std::string &xml_string);
-  URDFDOM_DLLAPI boost::shared_ptr<ModelInterface> parseURDFFile(const std::string &path);
-  URDFDOM_DLLAPI TiXmlDocument*  exportURDF(boost::shared_ptr<ModelInterface> &model);
+  URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDF(const std::string &xml_string);
+  URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDFFile(const std::string &path);
+  URDFDOM_DLLAPI TiXmlDocument*  exportURDF(ModelInterfaceSharedPtr &model);
   URDFDOM_DLLAPI TiXmlDocument*  exportURDF(const ModelInterface &model);
   URDFDOM_DLLAPI bool parsePose(Pose&, TiXmlElement*);
 }

--- a/urdf_parser/src/check_urdf.cpp
+++ b/urdf_parser/src/check_urdf.cpp
@@ -40,11 +40,11 @@
 
 using namespace urdf;
 
-void printTree(boost::shared_ptr<const Link> link,int level = 0)
+void printTree(LinkConstSharedPtr link,int level = 0)
 {
   level+=2;
   int count = 0;
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
   {
     if (*child)
     {
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
   }
   xml_file.close();
 
-  boost::shared_ptr<ModelInterface> robot = parseURDF(xml_string);
+  ModelInterfaceSharedPtr robot = parseURDF(xml_string);
   if (!robot){
     std::cerr << "ERROR: Model Parsing the xml failed" << std::endl;
     return -1;
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
   // get info from parser
   std::cout << "---------- Successfully Parsed XML ---------------" << std::endl;
   // get root link
-  boost::shared_ptr<const Link> root_link=robot->getRoot();
+  LinkConstSharedPtr root_link=robot->getRoot();
   if (!root_link) return -1;
 
   std::cout << "root Link: " << root_link->name << " has " << root_link->child_links.size() << " child(ren)" << std::endl;

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -546,21 +546,21 @@ bool exportMesh(Mesh &m, TiXmlElement *xml)
 bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml)
 {
   TiXmlElement *geometry_xml = new TiXmlElement("geometry");
-  if (boost::dynamic_pointer_cast<Sphere>(geom))
+  if (urdf::dynamic_pointer_cast<Sphere>(geom))
   {
-    exportSphere((*(boost::dynamic_pointer_cast<Sphere>(geom).get())), geometry_xml);
+    exportSphere((*(urdf::dynamic_pointer_cast<Sphere>(geom).get())), geometry_xml);
   }
-  else if (boost::dynamic_pointer_cast<Box>(geom))
+  else if (urdf::dynamic_pointer_cast<Box>(geom))
   {
-    exportBox((*(boost::dynamic_pointer_cast<Box>(geom).get())), geometry_xml);
+    exportBox((*(urdf::dynamic_pointer_cast<Box>(geom).get())), geometry_xml);
   }
-  else if (boost::dynamic_pointer_cast<Cylinder>(geom))
+  else if (urdf::dynamic_pointer_cast<Cylinder>(geom))
   {
-    exportCylinder((*(boost::dynamic_pointer_cast<Cylinder>(geom).get())), geometry_xml);
+    exportCylinder((*(urdf::dynamic_pointer_cast<Cylinder>(geom).get())), geometry_xml);
   }
-  else if (boost::dynamic_pointer_cast<Mesh>(geom))
+  else if (urdf::dynamic_pointer_cast<Mesh>(geom))
   {
-    exportMesh((*(boost::dynamic_pointer_cast<Mesh>(geom).get())), geometry_xml);
+    exportMesh((*(urdf::dynamic_pointer_cast<Mesh>(geom).get())), geometry_xml);
   }
   else
   {
@@ -568,7 +568,7 @@ bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml)
     Sphere *s = new Sphere();
     s->radius = 0.03;
     geom.reset(s);
-    exportSphere((*(boost::dynamic_pointer_cast<Sphere>(geom).get())), geometry_xml);
+    exportSphere((*(urdf::dynamic_pointer_cast<Sphere>(geom).get())), geometry_xml);
   }
 
   xml->LinkEndChild(geometry_xml);

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -220,9 +220,9 @@ bool parseMesh(Mesh &m, TiXmlElement *c)
   return true;
 }
 
-boost::shared_ptr<Geometry> parseGeometry(TiXmlElement *g)
+GeometrySharedPtr parseGeometry(TiXmlElement *g)
 {
-  boost::shared_ptr<Geometry> geom;
+  GeometrySharedPtr geom;
   if (!g) return geom;
 
   TiXmlElement *shape = g->FirstChildElement();
@@ -267,7 +267,7 @@ boost::shared_ptr<Geometry> parseGeometry(TiXmlElement *g)
     return geom;
   }
   
-  return boost::shared_ptr<Geometry>();
+  return GeometrySharedPtr();
 }
 
 bool parseInertial(Inertial &i, TiXmlElement *config)
@@ -440,7 +440,7 @@ bool parseLink(Link &link, TiXmlElement* config)
   for (TiXmlElement* vis_xml = config->FirstChildElement("visual"); vis_xml; vis_xml = vis_xml->NextSiblingElement("visual"))
   {
 
-    boost::shared_ptr<Visual> vis;
+    VisualSharedPtr vis;
     vis.reset(new Visual());
     if (parseVisual(*vis, vis_xml))
     {
@@ -462,7 +462,7 @@ bool parseLink(Link &link, TiXmlElement* config)
   // Multiple Collisions (optional)
   for (TiXmlElement* col_xml = config->FirstChildElement("collision"); col_xml; col_xml = col_xml->NextSiblingElement("collision"))
   {
-    boost::shared_ptr<Collision> col;
+    CollisionSharedPtr col;
     col.reset(new Collision());
     if (parseCollision(*col, col_xml))
     {      
@@ -543,7 +543,7 @@ bool exportMesh(Mesh &m, TiXmlElement *xml)
   return true;
 }
 
-bool exportGeometry(boost::shared_ptr<Geometry> &geom, TiXmlElement *xml)
+bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml)
 {
   TiXmlElement *geometry_xml = new TiXmlElement("geometry");
   if (boost::dynamic_pointer_cast<Sphere>(geom))

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -46,13 +46,13 @@ bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_o
 bool parseLink(Link &link, TiXmlElement *config);
 bool parseJoint(Joint &joint, TiXmlElement *config);
 
-boost::shared_ptr<ModelInterface>  parseURDFFile(const std::string &path)
+ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
 {
     std::ifstream stream( path.c_str() );
     if (!stream)
     {
       logError(("File " + path + " does not exist").c_str());
-      return boost::shared_ptr<ModelInterface>();
+      return ModelInterfaceSharedPtr();
     }
 
     std::string xml_str((std::istreambuf_iterator<char>(stream)),
@@ -60,9 +60,9 @@ boost::shared_ptr<ModelInterface>  parseURDFFile(const std::string &path)
     return urdf::parseURDF( xml_str );
 }
 
-boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
+ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
 {
-  boost::shared_ptr<ModelInterface> model(new ModelInterface);
+  ModelInterfaceSharedPtr model(new ModelInterface);
   model->clear();
 
   TiXmlDocument xml_doc;
@@ -96,7 +96,7 @@ boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
   // Get all Material elements
   for (TiXmlElement* material_xml = robot_xml->FirstChildElement("material"); material_xml; material_xml = material_xml->NextSiblingElement("material"))
   {
-    boost::shared_ptr<Material> material;
+    MaterialSharedPtr material;
     material.reset(new Material);
 
     try {
@@ -125,7 +125,7 @@ boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
   // Get all Link elements
   for (TiXmlElement* link_xml = robot_xml->FirstChildElement("link"); link_xml; link_xml = link_xml->NextSiblingElement("link"))
   {
-    boost::shared_ptr<Link> link;
+    LinkSharedPtr link;
     link.reset(new Link);
 
     try {
@@ -185,7 +185,7 @@ boost::shared_ptr<ModelInterface>  parseURDF(const std::string &xml_string)
   // Get all Joint elements
   for (TiXmlElement* joint_xml = robot_xml->FirstChildElement("joint"); joint_xml; joint_xml = joint_xml->NextSiblingElement("joint"))
   {
-    boost::shared_ptr<Joint> joint;
+    JointSharedPtr joint;
     joint.reset(new Joint);
 
     if (parseJoint(*joint, joint_xml))
@@ -255,19 +255,19 @@ TiXmlDocument*  exportURDF(const ModelInterface &model)
   doc->LinkEndChild(robot);
 
 
-  for (std::map<std::string, boost::shared_ptr<Material> >::const_iterator m=model.materials_.begin(); m!=model.materials_.end(); m++)
+  for (std::map<std::string, MaterialSharedPtr>::const_iterator m=model.materials_.begin(); m!=model.materials_.end(); m++)
   {
     logDebug("urdfdom: exporting material [%s]\n",m->second->name.c_str());
     exportMaterial(*(m->second), robot);
   }
 
-  for (std::map<std::string, boost::shared_ptr<Link> >::const_iterator l=model.links_.begin(); l!=model.links_.end(); l++)  
+  for (std::map<std::string, LinkSharedPtr>::const_iterator l=model.links_.begin(); l!=model.links_.end(); l++)  
   {
     logDebug("urdfdom: exporting link [%s]\n",l->second->name.c_str());
     exportLink(*(l->second), robot);
   }
   	
-  for (std::map<std::string, boost::shared_ptr<Joint> >::const_iterator j=model.joints_.begin(); j!=model.joints_.end(); j++)  
+  for (std::map<std::string, JointSharedPtr>::const_iterator j=model.joints_.begin(); j!=model.joints_.end(); j++)  
   {
     logDebug("urdfdom: exporting joint [%s]\n",j->second->name.c_str());
     exportJoint(*(j->second), robot);
@@ -276,7 +276,7 @@ TiXmlDocument*  exportURDF(const ModelInterface &model)
   return doc;
 }
     
-TiXmlDocument*  exportURDF(boost::shared_ptr<ModelInterface> &model)
+TiXmlDocument*  exportURDF(ModelInterfaceSharedPtr &model)
 {
   return exportURDF(*model);
 }

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -73,7 +73,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
   TiXmlElement *joint_state_elem = config->FirstChildElement("joint_state");
   if (joint_state_elem)
   {
-    boost::shared_ptr<JointState> joint_state;
+    JointStateSharedPtr joint_state;
     joint_state.reset(new JointState());
 
     const char *joint_char = joint_state_elem->Attribute("joint");

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -295,9 +295,9 @@ bool parseRay(Ray &ray, TiXmlElement* config)
   return false;
 }
 
-boost::shared_ptr<VisualSensor> parseVisualSensor(TiXmlElement *g)
+VisualSensorSharedPtr parseVisualSensor(TiXmlElement *g)
 {
-  boost::shared_ptr<VisualSensor> visual_sensor;
+  VisualSensorSharedPtr visual_sensor;
 
   // get sensor type
   TiXmlElement *sensor_xml;

--- a/urdf_parser/src/urdf_to_graphiz.cpp
+++ b/urdf_parser/src/urdf_to_graphiz.cpp
@@ -41,17 +41,17 @@
 using namespace urdf;
 using namespace std;
 
-void addChildLinkNames(boost::shared_ptr<const Link> link, ofstream& os)
+void addChildLinkNames(LinkConstSharedPtr link, ofstream& os)
 {
   os << "\"" << link->name << "\" [label=\"" << link->name << "\"];" << endl;
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
     addChildLinkNames(*child, os);
 }
 
-void addChildJointNames(boost::shared_ptr<const Link> link, ofstream& os)
+void addChildJointNames(LinkConstSharedPtr link, ofstream& os)
 {
   double r, p, y;
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
     (*child)->parent_joint->parent_to_joint_origin_transform.rotation.getRPY(r,p,y);
     os << "\"" << link->name << "\" -> \"" << (*child)->parent_joint->name 
        << "\" [label=\"xyz: "
@@ -65,7 +65,7 @@ void addChildJointNames(boost::shared_ptr<const Link> link, ofstream& os)
 }
 
 
-void printTree(boost::shared_ptr<const Link> link, string file)
+void printTree(LinkConstSharedPtr link, string file)
 {
   std::ofstream os;
   os.open(file.c_str());
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
   }
   xml_file.close();
 
-  boost::shared_ptr<ModelInterface> robot = parseURDF(xml_string);
+  ModelInterfaceSharedPtr robot = parseURDF(xml_string);
   if (!robot){
     std::cerr << "ERROR: Model Parsing the xml failed" << std::endl;
     return -1;


### PR DESCRIPTION
This uses the new pointer typedefs to aid in eventual migration away from boost smart pointers. It also uses the `urdf::dynamic_pointer_cast` function to aid in migration.

In order to use the new typedefs, we must find at least version 0.4 of `urdfdom_headers` (see https://github.com/ros/urdfdom_headers/pull/17 ), so we bump this version to 0.4 as well.