### PR TITLE
[test] add extended tests for pose::get/setRPY

### DIFF
--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -1,7 +1,8 @@
-#include "urdf_parser/urdf_parser.h"
+#include "urdf_model/pose.h"
 #include <iostream>
 #include <iomanip>
 #include <cmath>
+#include <vector>
 
 // the name of our test module
 #define BOOST_TEST_MODULE URDF_UNIT_TEST
@@ -56,10 +57,67 @@ void check_get_set_rpy_is_idempotent(double x, double y, double z, double w)
   BOOST_CHECK(quat_are_near(rot0, rot1));
 }
 
+void check_get_set_rpy_is_idempotent_from_rpy(double r, double p, double y)
+{
+  urdf::Rotation rot0;
+  rot0.setFromRPY(r, p, y);
+  double roll, pitch, yaw;
+  rot0.getRPY(roll, pitch, yaw);
+  urdf::Rotation rot1;
+  rot1.setFromRPY(roll, pitch, yaw);
+  bool ok = quat_are_near(rot0, rot1);
+  if (!ok) {
+    std::cout << "initial rpy: " << r << " " << p << " " << y << "\n"
+              << "before  " << rot0 << "\n"
+              << "after   " << rot1 << "\n"
+              << "ok      " << ok << "\n";
+  }
+  BOOST_CHECK(ok);
+}
+
 BOOST_AUTO_TEST_CASE(test_rotation_get_set_rpy_idempotent)
 {
   double x0 = 0.5, y0 = -0.5, z0 = 0.5,  w0 = 0.5;
   check_get_set_rpy_is_idempotent(x0, y0, z0, w0);
   double delta = 2.2e-8;
   check_get_set_rpy_is_idempotent(x0, y0, z0+delta, w0-delta);
+
+  // Checking consistency (in quaternion space) of set/get rpy
+  check_get_set_rpy_is_idempotent_from_rpy(0.0,-M_PI/2,0.0);
+
+
+  // More complete consistency check of set/get rpy
+  // We define a list of angles (some totally random,
+  // some instead are cornercase such as 0.0 or M_PI).
+  // Then we check the consistency for all possible
+  // permutations with repetition (nrOfAngles^3)
+  std::vector<double> testAngles;
+  testAngles.push_back(0.0);
+  testAngles.push_back(M_PI/4);
+  testAngles.push_back(M_PI/3);
+  testAngles.push_back(M_PI/2);
+  testAngles.push_back(M_PI);
+  testAngles.push_back(-M_PI/4);
+  testAngles.push_back(-M_PI/3);
+  testAngles.push_back(-M_PI/2);
+  testAngles.push_back(-M_PI);
+  testAngles.push_back(1.0);
+  testAngles.push_back(1.5);
+  testAngles.push_back(2.0);
+  testAngles.push_back(-1.0);
+  testAngles.push_back(-1.5);
+  testAngles.push_back(-2.0);
+
+  for(size_t rIdx = 0; rIdx < testAngles.size(); rIdx++ ) {
+    for(size_t pIdx = 0; pIdx < testAngles.size(); pIdx++ ) {
+      for(size_t yIdx = 0; yIdx < testAngles.size(); yIdx++ ) {
+            check_get_set_rpy_is_idempotent_from_rpy(testAngles[rIdx],
+                                                     testAngles[pIdx],
+                                                     testAngles[yIdx]);
+      }
+    }
+  }
+
+
+
 }


### PR DESCRIPTION
One testcase added to highlight https://github.com/ros/urdfdom_headers/issues/18

Furthermore, a vast range of rpy test cases (obtained
as the permutation of given list of angles) was added to
make sure that they are all handled properly.

By the way, why this test was added in this repository @vrabaud ? 
It is only testing code that is contained in the urdfdom_headers repo.
