### PR TITLE
fixed transmission parser to match specification

### DIFF
--- a/urdf_parser_py/CMakeLists.txt
+++ b/urdf_parser_py/CMakeLists.txt
@@ -1,7 +1,13 @@
 find_program(PYTHON "python")
 
-if (PYTHON)
-  set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/setup.py")
-  install(CODE "execute_process(COMMAND \"${PYTHON}\" \"${SETUP_PY}\" build --build-base \"${CMAKE_CURRENT_BINARY_DIR}/pybuild\" install --install-layout deb --prefix \"${CMAKE_INSTALL_PREFIX}\"
-                WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
+if (NOT PYTHON)
+  return()
 endif()
+
+set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/setup.py")
+install(CODE "execute_process(COMMAND \"${PYTHON}\" \"${SETUP_PY}\" build --build-base \"${CMAKE_CURRENT_BINARY_DIR}/pybuild\" install --install-layout deb --prefix \"${CMAKE_INSTALL_PREFIX}\"
+              WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
+
+add_test(NAME urdf_parser_py
+         COMMAND /usr/bin/env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/src ${PYTHON} test_urdf.py
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)

--- a/urdf_parser_py/src/urdf_parser_py/urdf.py
+++ b/urdf_parser_py/src/urdf_parser_py/urdf.py
@@ -349,15 +349,24 @@ xmlr.reflect(PR2Transmission, tag = 'pr2_transmission', params = [
 
 
 class Actuator(xmlr.Object):
-	def __init__(self, name = None, hardwareInterface = None, mechanicalReduction = 1):
+	def __init__(self, name = None, mechanicalReduction = 1):
 		self.name = name
-		self.hardwareInterface = None
 		self.mechanicalReduction = None
 
 xmlr.reflect(Actuator, tag = 'actuator', params = [
 		name_attribute,
-		xmlr.Element('hardwareInterface', str, required = False),
 		xmlr.Element('mechanicalReduction', float, required = False)
+		])
+
+class TransmissionJoint(xmlr.Object):
+	def __init__(self, name = None):
+		self.aggregate_init()
+		self.name = name
+		self.hardwareInterfaces = []
+
+xmlr.reflect(TransmissionJoint, tag = 'joint', params = [
+		name_attribute,
+		xmlr.AggregateElement('hardwareInterface', str),
 		])
 
 class Transmission(xmlr.Object):
@@ -370,7 +379,7 @@ class Transmission(xmlr.Object):
 xmlr.reflect(Transmission, tag = 'new_transmission', params = [
 		name_attribute,
 		xmlr.Element('type', str),
-		xmlr.Element('joint', 'element_name'),
+		xmlr.Element('joint', TransmissionJoint),
 		xmlr.Element('actuator', Actuator)
 		])
 

--- a/urdf_parser_py/src/urdf_parser_py/urdf.py
+++ b/urdf_parser_py/src/urdf_parser_py/urdf.py
@@ -362,6 +362,10 @@ class TransmissionJoint(xmlr.Object):
 		self.name = name
 		self.hardwareInterfaces = []
 
+	def check_valid(self):
+		assert len(self.hardwareInterfaces) > 0, "no hardwareInterface defined"
+
+
 xmlr.reflect(TransmissionJoint, tag = 'joint', params = [
 		name_attribute,
 		xmlr.AggregateElement('hardwareInterface', str),
@@ -369,16 +373,21 @@ xmlr.reflect(TransmissionJoint, tag = 'joint', params = [
 
 class Transmission(xmlr.Object):
 	""" New format: http://wiki.ros.org/urdf/XML/Transmission """
-	def __init__(self, name = None, joint = None, actuator = None):
+	def __init__(self, name = None):
+		self.aggregate_init()
 		self.name = name
-		self.joint = joint
-		self.actuator = actuator
+		self.joints = []
+		self.actuators = []
+
+	def check_valid(self):
+		assert len(self.joints) > 0, "no joint defined"
+		assert len(self.actuators) > 0, "no actuator defined"
 
 xmlr.reflect(Transmission, tag = 'new_transmission', params = [
 		name_attribute,
 		xmlr.Element('type', str),
-		xmlr.Element('joint', TransmissionJoint),
-		xmlr.Element('actuator', Actuator)
+		xmlr.AggregateElement('joint', TransmissionJoint),
+		xmlr.AggregateElement('actuator', Actuator)
 		])
 
 xmlr.add_type('transmission', xmlr.DuckTypedFactory('transmission', [Transmission, PR2Transmission]))

--- a/urdf_parser_py/src/urdf_parser_py/urdf.py
+++ b/urdf_parser_py/src/urdf_parser_py/urdf.py
@@ -275,7 +275,7 @@ class Joint(xmlr.Object):
 	def __init__(self, name=None, parent=None, child=None, joint_type=None,
 			axis=None, origin=None,
 			limit=None, dynamics=None, safety_controller=None, calibration=None,
-			mimic=None, hardwareInterface = None):
+			mimic=None):
 		self.name = name
 		self.parent = parent
 		self.child = child
@@ -287,7 +287,6 @@ class Joint(xmlr.Object):
 		self.safety_controller = safety_controller
 		self.calibration = calibration
 		self.mimic = mimic
-		self.hardwareInterface = hardwareInterface
 	
 	def check_valid(self):
 		assert self.type in self.TYPES, "Invalid joint type: {}".format(self.type)
@@ -310,7 +309,6 @@ xmlr.reflect(Joint, params = [
 	xmlr.Element('safety_controller', SafetyController, False),
 	xmlr.Element('calibration', JointCalibration, False),
 	xmlr.Element('mimic', JointMimic, False),
-	xmlr.Element('hardwareInterface', str, required= False)
 	])
 
 
@@ -461,12 +459,11 @@ class Robot(xmlr.Object):
 		return cls.from_xml_string(rospy.get_param(key))
 	
 xmlr.reflect(Robot, tag = 'robot', params = [
-# 	name_attribute,
 	xmlr.Attribute('name', str, False), # Is 'name' a required attribute?
 	xmlr.AggregateElement('link', Link),
 	xmlr.AggregateElement('joint', Joint),
 	xmlr.AggregateElement('gazebo', xmlr.RawType()),
- 	xmlr.AggregateElement('transmission', 'transmission'),
+	xmlr.AggregateElement('transmission', 'transmission'),
 	xmlr.AggregateElement('material', Material)
 	])
 

--- a/urdf_parser_py/test/test_urdf.py
+++ b/urdf_parser_py/test/test_urdf.py
@@ -6,6 +6,9 @@ from xml_matching import xml_matches
 from urdf_parser_py import urdf
 
 class TestURDFParser(unittest.TestCase):
+    def parse(self, xml):
+        return urdf.Robot.from_xml_string(xml)
+
     def parse_and_compare(self, orig):
         xml = minidom.parseString(orig)
         robot = urdf.Robot.from_xml_string(orig)
@@ -26,6 +29,62 @@ class TestURDFParser(unittest.TestCase):
   </transmission>
 </robot>'''
         self.parse_and_compare(xml)
+
+    def test_new_transmission_multiple_joints(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="foo_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="bar_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="foo_motor">
+      <mechanicalReduction>50.0</mechanicalReduction>
+    </actuator>
+  </transmission>
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_new_transmission_multiple_actuators(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="foo_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="foo_motor">
+      <mechanicalReduction>50.0</mechanicalReduction>
+    </actuator>
+    <actuator name="bar_motor"/>
+  </transmission>
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_new_transmission_missing_joint(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+  </transmission>
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_new_transmission_missing_actuator(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="foo_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+  </transmission>
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
 
     def test_old_transmission(self):
         xml = '''<?xml version="1.0"?>

--- a/urdf_parser_py/test/test_urdf.py
+++ b/urdf_parser_py/test/test_urdf.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+
+import unittest
+from xml.dom import minidom
+from xml_matching import xml_matches
+from urdf_parser_py import urdf
+
+class TestURDFParser(unittest.TestCase):
+    def parse_and_compare(self, orig):
+        xml = minidom.parseString(orig)
+        robot = urdf.Robot.from_xml_string(orig)
+        rewritten = minidom.parseString(robot.to_xml_string())
+        self.assertTrue(xml_matches(xml, rewritten))
+
+    def test_new_transmission(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="foo_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="foo_motor">
+      <mechanicalReduction>50.0</mechanicalReduction>
+    </actuator>
+  </transmission>
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_old_transmission(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <transmission name="PR2_trans" type="SimpleTransmission">
+    <joint name="foo_joint"/>
+    <actuator name="foo_motor"/>
+    <mechanicalReduction>1.0</mechanicalReduction>
+  </transmission>
+</robot>'''
+        self.parse_and_compare(xml)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/urdf_parser_py/test/xml_matching.py
+++ b/urdf_parser_py/test/xml_matching.py
@@ -1,0 +1,110 @@
+import xml.dom
+import re
+import sys
+
+# regex to match whitespace
+whitespace = re.compile(r'\s+')
+
+def all_attributes_match(a, b):
+    if len(a.attributes) != len(b.attributes):
+        print("Different number of attributes")
+        return False
+    a_atts = [(a.attributes.item(i).name, a.attributes.item(i).value) for i in range(len(a.attributes))]
+    b_atts = [(b.attributes.item(i).name, b.attributes.item(i).value) for i in range(len(b.attributes))]
+    a_atts.sort()
+    b_atts.sort()
+
+    for i in range(len(a_atts)):
+        if a_atts[i][0] != b_atts[i][0]:
+            print("Different attribute names: %s and %s" % (a_atts[i][0], b_atts[i][0]))
+            return False
+        try:
+            if abs(float(a_atts[i][1]) - float(b_atts[i][1])) > 1.0e-9:
+                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))
+                return False
+        except ValueError:  # Attribute values aren't numeric
+            if a_atts[i][1] != b_atts[i][1]:
+                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))
+                return False
+
+    return True
+
+
+def text_matches(a, b):
+    a_norm = whitespace.sub(' ', a)
+    b_norm = whitespace.sub(' ', b)
+    if a_norm.strip() == b_norm.strip(): return True
+    print("Different text values: '%s' and '%s'" % (a, b))
+    return False
+
+
+def nodes_match(a, b, ignore_nodes):
+    if not a and not b:
+        return True
+    if not a or not b:
+        return False
+
+    if a.nodeType != b.nodeType:
+        print("Different node types: %s and %s" % (a, b))
+        return False
+
+    # compare text-valued nodes
+    if a.nodeType in [xml.dom.Node.TEXT_NODE,
+                      xml.dom.Node.CDATA_SECTION_NODE,
+                      xml.dom.Node.COMMENT_NODE]:
+        return text_matches(a.data, b.data)
+
+    # ignore all other nodes except ELEMENTs
+    if a.nodeType != xml.dom.Node.ELEMENT_NODE:
+        return True
+
+    # compare ELEMENT nodes
+    if a.nodeName != b.nodeName:
+        print("Different element names: %s and %s" % (a.nodeName, b.nodeName))
+        return False
+
+    if not all_attributes_match(a, b):
+        return False
+
+    a = a.firstChild
+    b = b.firstChild
+    while a or b:
+        # ignore whitespace-only text nodes
+        # we could have several text nodes in a row, due to replacements
+        while (a and
+               ((a.nodeType in ignore_nodes) or
+                (a.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', a.data) == ""))):
+            a = a.nextSibling
+        while (b and
+               ((b.nodeType in ignore_nodes) or
+                (b.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', b.data) == ""))):
+            b = b.nextSibling
+
+        if not nodes_match(a, b, ignore_nodes):
+            return False
+
+        if a: a = a.nextSibling
+        if b: b = b.nextSibling
+
+    return True
+
+
+def xml_matches(a, b, ignore_nodes=[]):
+    if isinstance(a, str):
+        return xml_matches(xml.dom.minidom.parseString(a).documentElement, b, ignore_nodes)
+    if isinstance(b, str):
+        return xml_matches(a, xml.dom.minidom.parseString(b).documentElement, ignore_nodes)
+    if a.nodeType == xml.dom.Node.DOCUMENT_NODE:
+        return xml_matches(a.documentElement, b, ignore_nodes)
+    if b.nodeType == xml.dom.Node.DOCUMENT_NODE:
+        return xml_matches(a, b.documentElement, ignore_nodes)
+
+    if not nodes_match(a, b, ignore_nodes):
+        print("Match failed:")
+        a.writexml(sys.stdout)
+        print()
+        print('=' * 78)
+        b.writexml(sys.stdout)
+        print()
+        return False
+    return True


### PR DESCRIPTION
The new transmission parser of `urdf_parser_py` didn't match the specification in the [wiki](http://wiki.ros.org/urdf/XML/Transmission#A.3Ctransmission.3E_Elements).

Moved `hardwareInterface` from `<actuator>` to `<joint>` and made them an aggregate (one to many such elements are possible according to specification).

