### PR TITLE
Add missing return statement

### DIFF
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -510,6 +510,8 @@ bool parseLink(Link &link, TiXmlElement* config)
   // Assign the first collision to the .collision ptr, if it exists
   if (!link.collision_array.empty())
     link.collision = link.collision_array[0];
+
+  return true;
 }
 
 /* exports */


### PR DESCRIPTION
The return signature of `parseLink` is bool, but the control flow of the function could reach the end of the function without returning bool.

This was causing a segfault in `urdf_parser` when I built it from source.