### PR TITLE
Color and texture in link material are optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
 script: "./.travis/build"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libboost-test-dev libtinyxml-dev python-yaml
+  - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libboost-test-dev libtinyxml-dev python-yaml python-mock
 matrix:
   allow_failures:
     - compiler: clang

--- a/urdf_parser_py/src/urdf_parser_py/urdf.py
+++ b/urdf_parser_py/src/urdf_parser_py/urdf.py
@@ -169,6 +169,9 @@ xmlr.reflect(Material, params = [
 	xmlr.Element('texture', Texture, False)
 	])
 
+class LinkMaterial(Material):
+	def check_valid(self):
+		pass
 
 class Visual(xmlr.Object):
 	def __init__(self, geometry = None, material = None, origin = None):
@@ -179,7 +182,7 @@ class Visual(xmlr.Object):
 xmlr.reflect(Visual, params = [
 	origin_element,
 	xmlr.Element('geometry', 'geometric'),
-	xmlr.Element('material', Material, False)
+	xmlr.Element('material', LinkMaterial, False)
 	])
 
 

--- a/urdf_parser_py/test/test_urdf.py
+++ b/urdf_parser_py/test/test_urdf.py
@@ -1,11 +1,17 @@
 from __future__ import print_function
 
 import unittest
+import mock
 from xml.dom import minidom
 from xml_matching import xml_matches
 from urdf_parser_py import urdf
 
+class ParseException(Exception):
+    pass
+
 class TestURDFParser(unittest.TestCase):
+    @mock.patch('urdf_parser_py.xml_reflection.on_error',
+                mock.Mock(side_effect=ParseException))
     def parse(self, xml):
         return urdf.Robot.from_xml_string(xml)
 
@@ -96,6 +102,36 @@ class TestURDFParser(unittest.TestCase):
   </transmission>
 </robot>'''
         self.parse_and_compare(xml)
+
+    def test_link_material_missing_color_and_texture(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <link name="link">
+    <visual>
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+      <material name="mat"/>
+    </visual>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_robot_material(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <material name="mat">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_robot_material_missing_color_and_texture(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <material name="mat"/>
+</robot>'''
+        self.assertRaises(ParseException, self.parse, xml)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
According to http://wiki.ros.org/urdf/XML/link#line-79, a material of a link can be referenced only by name. But if neither a color tag nor a texture tag is present within a material tag, "Material has neither a color nor texture" error occurs.

This PR suppresses the above error.