### PR TITLE
Use console_bridge 0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories(SYSTEM ${TinyXML_INCLUDE_DIRS})
 find_package(urdfdom_headers 0.4 REQUIRED)
 include_directories(SYSTEM ${urdfdom_headers_INCLUDE_DIRS})
 
-find_package(console_bridge REQUIRED)
+find_package(console_bridge 0.3 REQUIRED)
 include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
 link_directories(${console_bridge_LIBRARY_DIRS})
 

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -52,7 +52,7 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
   // Get joint damping
   const char* damping_str = config->Attribute("damping");
   if (damping_str == NULL){
-    logDebug("urdfdom.joint_dynamics: no damping, defaults to 0");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_dynamics: no damping, defaults to 0");
     jd.damping = 0;
   }
   else
@@ -71,7 +71,7 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
   // Get joint friction
   const char* friction_str = config->Attribute("friction");
   if (friction_str == NULL){
-    logDebug("urdfdom.joint_dynamics: no friction, defaults to 0");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_dynamics: no friction, defaults to 0");
     jd.friction = 0;
   }
   else
@@ -93,7 +93,7 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
     return false;
   }
   else{
-    logDebug("urdfdom.joint_dynamics: damping %f and friction %f", jd.damping, jd.friction);
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_dynamics: damping %f and friction %f", jd.damping, jd.friction);
     return true;
   }
 }
@@ -105,7 +105,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   // Get lower joint limit
   const char* lower_str = config->Attribute("lower");
   if (lower_str == NULL){
-    logDebug("urdfdom.joint_limit: no lower, defaults to 0");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_limit: no lower, defaults to 0");
     jl.lower = 0;
   }
   else
@@ -124,7 +124,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   // Get upper joint limit
   const char* upper_str = config->Attribute("upper");
   if (upper_str == NULL){
-    logDebug("urdfdom.joint_limit: no upper, , defaults to 0");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_limit: no upper, , defaults to 0");
     jl.upper = 0;
   }
   else
@@ -189,7 +189,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   const char* soft_lower_limit_str = config->Attribute("soft_lower_limit");
   if (soft_lower_limit_str == NULL)
   {
-    logDebug("urdfdom.joint_safety: no soft_lower_limit, using default value");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_safety: no soft_lower_limit, using default value");
     js.soft_lower_limit = 0;
   }
   else
@@ -209,7 +209,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   const char* soft_upper_limit_str = config->Attribute("soft_upper_limit");
   if (soft_upper_limit_str == NULL)
   {
-    logDebug("urdfdom.joint_safety: no soft_upper_limit, using default value");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_safety: no soft_upper_limit, using default value");
     js.soft_upper_limit = 0;
   }
   else
@@ -229,7 +229,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   const char* k_position_str = config->Attribute("k_position");
   if (k_position_str == NULL)
   {
-    logDebug("urdfdom.joint_safety: no k_position, using default value");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_safety: no k_position, using default value");
     js.k_position = 0;
   }
   else
@@ -275,7 +275,7 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
   const char* rising_position_str = config->Attribute("rising");
   if (rising_position_str == NULL)
   {
-    logDebug("urdfdom.joint_calibration: no rising, using default value");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_calibration: no rising, using default value");
     jc.rising.reset();
   }
   else
@@ -295,7 +295,7 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
   const char* falling_position_str = config->Attribute("falling");
   if (falling_position_str == NULL)
   {
-    logDebug("urdfdom.joint_calibration: no falling, using default value");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_calibration: no falling, using default value");
     jc.falling.reset();
   }
   else
@@ -334,7 +334,7 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
 
   if (multiplier_str == NULL)
   {
-    logDebug("urdfdom.joint_mimic: no multiplier, using default value of 1");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_mimic: no multiplier, using default value of 1");
     jm.multiplier = 1;    
   }
   else
@@ -355,7 +355,7 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
   const char* offset_str = config->Attribute("offset");
   if (offset_str == NULL)
   {
-    logDebug("urdfdom.joint_mimic: no offset, using default value of 0");
+    CONSOLE_BRIDGE_logDebug("urdfdom.joint_mimic: no offset, using default value of 0");
     jm.offset = 0;
   }
   else
@@ -391,7 +391,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
   TiXmlElement *origin_xml = config->FirstChildElement("origin");
   if (!origin_xml)
   {
-    logDebug("urdfdom: Joint [%s] missing origin tag under parent describing transform from Parent Link to Joint Frame, (using Identity transform).", joint.name.c_str());
+    CONSOLE_BRIDGE_logDebug("urdfdom: Joint [%s] missing origin tag under parent describing transform from Parent Link to Joint Frame, (using Identity transform).", joint.name.c_str());
     joint.parent_to_joint_origin_transform.clear();
   }
   else
@@ -467,7 +467,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     // axis
     TiXmlElement *axis_xml = config->FirstChildElement("axis");
     if (!axis_xml){
-      logDebug("urdfdom: no axis elemement for Joint link [%s], defaulting to (1,0,0) axis", joint.name.c_str());
+      CONSOLE_BRIDGE_logDebug("urdfdom: no axis elemement for Joint link [%s], defaulting to (1,0,0) axis", joint.name.c_str());
       joint.axis = Vector3(1.0, 0.0, 0.0);
     }
     else{

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -411,7 +411,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     const char *pname = parent_xml->Attribute("link");
     if (!pname)
     {
-      logInform("no parent link name specified for Joint link [%s]. this might be the root?", joint.name.c_str());
+      CONSOLE_BRIDGE_logInform("no parent link name specified for Joint link [%s]. this might be the root?", joint.name.c_str());
     }
     else
     {
@@ -426,7 +426,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     const char *pname = child_xml->Attribute("link");
     if (!pname)
     {
-      logInform("no child link name specified for Joint link [%s].", joint.name.c_str());
+      CONSOLE_BRIDGE_logInform("no child link name specified for Joint link [%s].", joint.name.c_str());
     }
     else
     {

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -63,7 +63,7 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("damping value (%s) is not a float: %s",damping_str, e.what());
+      CONSOLE_BRIDGE_logError("damping value (%s) is not a float: %s",damping_str, e.what());
       return false;
     }
   }
@@ -82,14 +82,14 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("friction value (%s) is not a float: %s",friction_str, e.what());
+      CONSOLE_BRIDGE_logError("friction value (%s) is not a float: %s",friction_str, e.what());
       return false;
     }
   }
 
   if (damping_str == NULL && friction_str == NULL)
   {
-    logError("joint dynamics element specified with no damping and no friction");
+    CONSOLE_BRIDGE_logError("joint dynamics element specified with no damping and no friction");
     return false;
   }
   else{
@@ -116,7 +116,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("lower value (%s) is not a float: %s", lower_str, e.what());
+      CONSOLE_BRIDGE_logError("lower value (%s) is not a float: %s", lower_str, e.what());
       return false;
     }
   }
@@ -135,7 +135,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("upper value (%s) is not a float: %s",upper_str, e.what());
+      CONSOLE_BRIDGE_logError("upper value (%s) is not a float: %s",upper_str, e.what());
       return false;
     }
   }
@@ -143,7 +143,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   // Get joint effort limit
   const char* effort_str = config->Attribute("effort");
   if (effort_str == NULL){
-    logError("joint limit: no effort");
+    CONSOLE_BRIDGE_logError("joint limit: no effort");
     return false;
   }
   else
@@ -154,7 +154,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("effort value (%s) is not a float: %s",effort_str, e.what());
+      CONSOLE_BRIDGE_logError("effort value (%s) is not a float: %s",effort_str, e.what());
       return false;
     }
   }
@@ -162,7 +162,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   // Get joint velocity limit
   const char* velocity_str = config->Attribute("velocity");
   if (velocity_str == NULL){
-    logError("joint limit: no velocity");
+    CONSOLE_BRIDGE_logError("joint limit: no velocity");
     return false;
   }
   else
@@ -173,7 +173,7 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("velocity value (%s) is not a float: %s",velocity_str, e.what());
+      CONSOLE_BRIDGE_logError("velocity value (%s) is not a float: %s",velocity_str, e.what());
       return false;
     }
   }
@@ -200,7 +200,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("soft_lower_limit value (%s) is not a float: %s",soft_lower_limit_str, e.what());
+      CONSOLE_BRIDGE_logError("soft_lower_limit value (%s) is not a float: %s",soft_lower_limit_str, e.what());
       return false;
     }
   }
@@ -220,7 +220,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("soft_upper_limit value (%s) is not a float: %s",soft_upper_limit_str, e.what());
+      CONSOLE_BRIDGE_logError("soft_upper_limit value (%s) is not a float: %s",soft_upper_limit_str, e.what());
       return false;
     }
   }
@@ -240,7 +240,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("k_position value (%s) is not a float: %s",k_position_str, e.what());
+      CONSOLE_BRIDGE_logError("k_position value (%s) is not a float: %s",k_position_str, e.what());
       return false;
     }
   }
@@ -248,7 +248,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   const char* k_velocity_str = config->Attribute("k_velocity");
   if (k_velocity_str == NULL)
   {
-    logError("joint safety: no k_velocity");
+    CONSOLE_BRIDGE_logError("joint safety: no k_velocity");
     return false;
   }
   else
@@ -259,7 +259,7 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("k_velocity value (%s) is not a float: %s",k_velocity_str, e.what());
+      CONSOLE_BRIDGE_logError("k_velocity value (%s) is not a float: %s",k_velocity_str, e.what());
       return false;
     }
   }
@@ -286,7 +286,7 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("risingvalue (%s) is not a float: %s",rising_position_str, e.what());
+      CONSOLE_BRIDGE_logError("risingvalue (%s) is not a float: %s",rising_position_str, e.what());
       return false;
     }
   }
@@ -306,7 +306,7 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("fallingvalue (%s) is not a float: %s",falling_position_str, e.what());
+      CONSOLE_BRIDGE_logError("fallingvalue (%s) is not a float: %s",falling_position_str, e.what());
       return false;
     }
   }
@@ -323,7 +323,7 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
 
   if (joint_name_str == NULL)
   {
-    logError("joint mimic: no mimic joint specified");
+    CONSOLE_BRIDGE_logError("joint mimic: no mimic joint specified");
     return false;
   }
   else
@@ -345,7 +345,7 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("multiplier value (%s) is not a float: %s",multiplier_str, e.what());
+      CONSOLE_BRIDGE_logError("multiplier value (%s) is not a float: %s",multiplier_str, e.what());
       return false;
     }
   }
@@ -366,7 +366,7 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
     }
     catch (boost::bad_lexical_cast &e)
     {
-      logError("offset value (%s) is not a float: %s",offset_str, e.what());
+      CONSOLE_BRIDGE_logError("offset value (%s) is not a float: %s",offset_str, e.what());
       return false;
     }
   }
@@ -382,7 +382,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
   const char *name = config->Attribute("name");
   if (!name)
   {
-    logError("unnamed joint found");
+    CONSOLE_BRIDGE_logError("unnamed joint found");
     return false;
   }
   joint.name = name;
@@ -399,7 +399,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     if (!parsePose(joint.parent_to_joint_origin_transform, origin_xml))
     {
       joint.parent_to_joint_origin_transform.clear();
-      logError("Malformed parent origin element for joint [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Malformed parent origin element for joint [%s]", joint.name.c_str());
       return false;
     }
   }
@@ -438,7 +438,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
   const char* type_char = config->Attribute("type");
   if (!type_char)
   {
-    logError("joint [%s] has no type, check to see if it's a reference.", joint.name.c_str());
+    CONSOLE_BRIDGE_logError("joint [%s] has no type, check to see if it's a reference.", joint.name.c_str());
     return false;
   }
   
@@ -457,7 +457,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.type = Joint::FIXED;
   else
   {
-    logError("Joint [%s] has no known type [%s]", joint.name.c_str(), type_str.c_str());
+    CONSOLE_BRIDGE_logError("Joint [%s] has no known type [%s]", joint.name.c_str(), type_str.c_str());
     return false;
   }
 
@@ -477,7 +477,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
         }
         catch (ParseError &e) {
           joint.axis.clear();
-          logError("Malformed axis element for joint [%s]: %s", joint.name.c_str(), e.what());
+          CONSOLE_BRIDGE_logError("Malformed axis element for joint [%s]: %s", joint.name.c_str(), e.what());
           return false;
         }
       }
@@ -491,19 +491,19 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.limits.reset(new JointLimits());
     if (!parseJointLimits(*joint.limits, limit_xml))
     {
-      logError("Could not parse limit element for joint [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse limit element for joint [%s]", joint.name.c_str());
       joint.limits.reset();
       return false;
     }
   }
   else if (joint.type == Joint::REVOLUTE)
   {
-    logError("Joint [%s] is of type REVOLUTE but it does not specify limits", joint.name.c_str());
+    CONSOLE_BRIDGE_logError("Joint [%s] is of type REVOLUTE but it does not specify limits", joint.name.c_str());
     return false;
   }
   else if (joint.type == Joint::PRISMATIC)
   {
-    logError("Joint [%s] is of type PRISMATIC without limits", joint.name.c_str()); 
+    CONSOLE_BRIDGE_logError("Joint [%s] is of type PRISMATIC without limits", joint.name.c_str()); 
     return false;
   }
 
@@ -514,7 +514,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.safety.reset(new JointSafety());
     if (!parseJointSafety(*joint.safety, safety_xml))
     {
-      logError("Could not parse safety element for joint [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse safety element for joint [%s]", joint.name.c_str());
       joint.safety.reset();
       return false;
     }
@@ -527,7 +527,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.calibration.reset(new JointCalibration());
     if (!parseJointCalibration(*joint.calibration, calibration_xml))
     {
-      logError("Could not parse calibration element for joint  [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse calibration element for joint  [%s]", joint.name.c_str());
       joint.calibration.reset();
       return false;
     }
@@ -540,7 +540,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.mimic.reset(new JointMimic());
     if (!parseJointMimic(*joint.mimic, mimic_xml))
     {
-      logError("Could not parse mimic element for joint  [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse mimic element for joint  [%s]", joint.name.c_str());
       joint.mimic.reset();
       return false;
     }
@@ -553,7 +553,7 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
     joint.dynamics.reset(new JointDynamics());
     if (!parseJointDynamics(*joint.dynamics, prop_xml))
     {
-      logError("Could not parse joint_dynamics element for joint [%s]", joint.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse joint_dynamics element for joint [%s]", joint.name.c_str());
       joint.dynamics.reset();
       return false;
     }
@@ -642,7 +642,7 @@ bool exportJoint(Joint &joint, TiXmlElement* xml)
   else if (joint.type == urdf::Joint::FIXED)
     joint_xml->SetAttribute("type", "fixed");
   else
-    logError("ERROR:  Joint [%s] type [%d] is not a defined type.\n",joint.name.c_str(), joint.type);
+    CONSOLE_BRIDGE_logError("ERROR:  Joint [%s] type [%d] is not a defined type.\n",joint.name.c_str(), joint.type);
 
   // origin
   exportPose(joint.parent_to_joint_origin_transform, joint_xml);

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -380,7 +380,7 @@ bool parseVisual(Visual &vis, TiXmlElement *config)
     vis.material.reset(new Material());
     if (!parseMaterial(*vis.material, mat, true))
     {
-      logDebug("urdfdom: material has only name, actual material definition may be in the model");
+      CONSOLE_BRIDGE_logDebug("urdfdom: material has only name, actual material definition may be in the model");
     }
   }
   

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -57,7 +57,7 @@ bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_o
 
   if (!config->Attribute("name"))
   {
-    logError("Material must contain a name attribute");
+    CONSOLE_BRIDGE_logError("Material must contain a name attribute");
     return false;
   }
   
@@ -86,7 +86,7 @@ bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_o
       }
       catch (ParseError &e) {  
         material.color.clear();
-        logError(std::string("Material [" + material.name + "] has malformed color rgba values: " + e.what()).c_str());
+        CONSOLE_BRIDGE_logError(std::string("Material [" + material.name + "] has malformed color rgba values: " + e.what()).c_str());
       }
     }
   }
@@ -94,8 +94,8 @@ bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_o
   if (!has_rgb && !has_filename) {
     if (!only_name_is_ok) // no need for an error if only name is ok
     {
-      if (!has_rgb) logError(std::string("Material ["+material.name+"] color has no rgba").c_str());
-      if (!has_filename) logError(std::string("Material ["+material.name+"] not defined in file").c_str());
+      if (!has_rgb) CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] color has no rgba").c_str());
+      if (!has_filename) CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] not defined in file").c_str());
     }
     return false;
   }
@@ -110,7 +110,7 @@ bool parseSphere(Sphere &s, TiXmlElement *c)
   s.type = Geometry::SPHERE;
   if (!c->Attribute("radius"))
   {
-    logError("Sphere shape must have a radius attribute");
+    CONSOLE_BRIDGE_logError("Sphere shape must have a radius attribute");
     return false;
   }
 
@@ -122,7 +122,7 @@ bool parseSphere(Sphere &s, TiXmlElement *c)
   {
     std::stringstream stm;
     stm << "radius [" << c->Attribute("radius") << "] is not a valid float: " << e.what();
-    logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError(stm.str().c_str());
     return false;
   }
   
@@ -136,7 +136,7 @@ bool parseBox(Box &b, TiXmlElement *c)
   b.type = Geometry::BOX;
   if (!c->Attribute("size"))
   {
-    logError("Box shape has no size attribute");
+    CONSOLE_BRIDGE_logError("Box shape has no size attribute");
     return false;
   }
   try
@@ -146,7 +146,7 @@ bool parseBox(Box &b, TiXmlElement *c)
   catch (ParseError &e)
   {
     b.dim.clear();
-    logError(e.what());
+    CONSOLE_BRIDGE_logError(e.what());
     return false;
   }
   return true;
@@ -160,7 +160,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
   if (!c->Attribute("length") ||
       !c->Attribute("radius"))
   {
-    logError("Cylinder shape must have both length and radius attributes");
+    CONSOLE_BRIDGE_logError("Cylinder shape must have both length and radius attributes");
     return false;
   }
 
@@ -172,7 +172,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
   {
     std::stringstream stm;
     stm << "length [" << c->Attribute("length") << "] is not a valid float";
-    logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError(stm.str().c_str());
     return false;
   }
 
@@ -184,7 +184,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
   {
     std::stringstream stm;
     stm << "radius [" << c->Attribute("radius") << "] is not a valid float";
-    logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError(stm.str().c_str());
     return false;
   }
   return true;
@@ -197,7 +197,7 @@ bool parseMesh(Mesh &m, TiXmlElement *c)
 
   m.type = Geometry::MESH;
   if (!c->Attribute("filename")) {
-    logError("Mesh must contain a filename attribute");
+    CONSOLE_BRIDGE_logError("Mesh must contain a filename attribute");
     return false;
   }
 
@@ -209,7 +209,7 @@ bool parseMesh(Mesh &m, TiXmlElement *c)
     }
     catch (ParseError &e) {
       m.scale.clear();
-      logError("Mesh scale was specified, but could not be parsed: %s", e.what());
+      CONSOLE_BRIDGE_logError("Mesh scale was specified, but could not be parsed: %s", e.what());
       return false;
     }
   }
@@ -228,7 +228,7 @@ GeometrySharedPtr parseGeometry(TiXmlElement *g)
   TiXmlElement *shape = g->FirstChildElement();
   if (!shape)
   {
-    logError("Geometry tag contains no child element.");
+    CONSOLE_BRIDGE_logError("Geometry tag contains no child element.");
     return geom;
   }
 
@@ -263,7 +263,7 @@ GeometrySharedPtr parseGeometry(TiXmlElement *g)
   }
   else
   {
-    logError("Unknown geometry type '%s'", type_name.c_str());
+    CONSOLE_BRIDGE_logError("Unknown geometry type '%s'", type_name.c_str());
     return geom;
   }
   
@@ -285,12 +285,12 @@ bool parseInertial(Inertial &i, TiXmlElement *config)
   TiXmlElement *mass_xml = config->FirstChildElement("mass");
   if (!mass_xml)
   {
-    logError("Inertial element must have a mass element");
+    CONSOLE_BRIDGE_logError("Inertial element must have a mass element");
     return false;
   }
   if (!mass_xml->Attribute("value"))
   {
-    logError("Inertial: mass element must have value attribute");
+    CONSOLE_BRIDGE_logError("Inertial: mass element must have value attribute");
     return false;
   }
 
@@ -303,21 +303,21 @@ bool parseInertial(Inertial &i, TiXmlElement *config)
     std::stringstream stm;
     stm << "Inertial: mass [" << mass_xml->Attribute("value")
         << "] is not a float";
-    logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError(stm.str().c_str());
     return false;
   }
 
   TiXmlElement *inertia_xml = config->FirstChildElement("inertia");
   if (!inertia_xml)
   {
-    logError("Inertial element must have inertia element");
+    CONSOLE_BRIDGE_logError("Inertial element must have inertia element");
     return false;
   }
   if (!(inertia_xml->Attribute("ixx") && inertia_xml->Attribute("ixy") && inertia_xml->Attribute("ixz") &&
         inertia_xml->Attribute("iyy") && inertia_xml->Attribute("iyz") &&
         inertia_xml->Attribute("izz")))
   {
-    logError("Inertial: inertia element must have ixx,ixy,ixz,iyy,iyz,izz attributes");
+    CONSOLE_BRIDGE_logError("Inertial: inertia element must have ixx,ixy,ixz,iyy,iyz,izz attributes");
     return false;
   }
   try
@@ -339,7 +339,7 @@ bool parseInertial(Inertial &i, TiXmlElement *config)
         << " iyy [" << inertia_xml->Attribute("iyy") << "]"
         << " iyz [" << inertia_xml->Attribute("iyz") << "]"
         << " izz [" << inertia_xml->Attribute("izz") << "]";
-    logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError(stm.str().c_str());
     return false;
   }
   return true;
@@ -371,7 +371,7 @@ bool parseVisual(Visual &vis, TiXmlElement *config)
   if (mat) {
     // get material name
     if (!mat->Attribute("name")) {
-      logError("Visual material must contain a name attribute");
+      CONSOLE_BRIDGE_logError("Visual material must contain a name attribute");
       return false;
     }
     vis.material_name = mat->Attribute("name");
@@ -419,7 +419,7 @@ bool parseLink(Link &link, TiXmlElement* config)
   const char *name_char = config->Attribute("name");
   if (!name_char)
   {
-    logError("No name given for the link.");
+    CONSOLE_BRIDGE_logError("No name given for the link.");
     return false;
   }
   link.name = std::string(name_char);
@@ -431,7 +431,7 @@ bool parseLink(Link &link, TiXmlElement* config)
     link.inertial.reset(new Inertial());
     if (!parseInertial(*link.inertial, i))
     {
-      logError("Could not parse inertial element for Link [%s]", link.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse inertial element for Link [%s]", link.name.c_str());
       return false;
     }
   }
@@ -449,7 +449,7 @@ bool parseLink(Link &link, TiXmlElement* config)
     else
     {
       vis.reset();
-      logError("Could not parse visual element for Link [%s]", link.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse visual element for Link [%s]", link.name.c_str());
       return false;
     }
   }
@@ -471,7 +471,7 @@ bool parseLink(Link &link, TiXmlElement* config)
     else
     {
       col.reset();
-      logError("Could not parse collision element for Link [%s]",  link.name.c_str());
+      CONSOLE_BRIDGE_logError("Could not parse collision element for Link [%s]",  link.name.c_str());
       return false;
     }
   }
@@ -564,7 +564,7 @@ bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml)
   }
   else
   {
-    logError("geometry not specified, I'll make one up for you!");
+    CONSOLE_BRIDGE_logError("geometry not specified, I'll make one up for you!");
     Sphere *s = new Sphere();
     s->radius = 0.03;
     geom.reset(s);

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -111,7 +111,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       else
       {
         model->materials_.insert(make_pair(material->name,material));
-        logDebug("urdfdom: successfully added a new material '%s'", material->name.c_str());
+        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new material '%s'", material->name.c_str());
       }
     }
     catch (ParseError &/*e*/) {
@@ -139,21 +139,21 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       else
       {
         // set link visual material
-        logDebug("urdfdom: setting link '%s' material", link->name.c_str());
+        CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material", link->name.c_str());
         if (link->visual)
         {
           if (!link->visual->material_name.empty())
           {
             if (model->getMaterial(link->visual->material_name))
             {
-              logDebug("urdfdom: setting link '%s' material to '%s'", link->name.c_str(),link->visual->material_name.c_str());
+              CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material to '%s'", link->name.c_str(),link->visual->material_name.c_str());
               link->visual->material = model->getMaterial( link->visual->material_name.c_str() );
             }
             else
             {
               if (link->visual->material)
               {
-                logDebug("urdfdom: link '%s' material '%s' defined in Visual.", link->name.c_str(),link->visual->material_name.c_str());
+                CONSOLE_BRIDGE_logDebug("urdfdom: link '%s' material '%s' defined in Visual.", link->name.c_str(),link->visual->material_name.c_str());
                 model->materials_.insert(make_pair(link->visual->material->name,link->visual->material));
               }
               else
@@ -167,7 +167,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
         }
 
         model->links_.insert(make_pair(link->name,link));
-        logDebug("urdfdom: successfully added a new link '%s'", link->name.c_str());
+        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new link '%s'", link->name.c_str());
       }
     }
     catch (ParseError &/*e*/) {
@@ -199,7 +199,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       else
       {
         model->joints_.insert(make_pair(joint->name,joint));
-        logDebug("urdfdom: successfully added a new joint '%s'", joint->name.c_str());
+        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new joint '%s'", joint->name.c_str());
       }
     }
     else
@@ -257,19 +257,19 @@ TiXmlDocument*  exportURDF(const ModelInterface &model)
 
   for (std::map<std::string, MaterialSharedPtr>::const_iterator m=model.materials_.begin(); m!=model.materials_.end(); m++)
   {
-    logDebug("urdfdom: exporting material [%s]\n",m->second->name.c_str());
+    CONSOLE_BRIDGE_logDebug("urdfdom: exporting material [%s]\n",m->second->name.c_str());
     exportMaterial(*(m->second), robot);
   }
 
   for (std::map<std::string, LinkSharedPtr>::const_iterator l=model.links_.begin(); l!=model.links_.end(); l++)  
   {
-    logDebug("urdfdom: exporting link [%s]\n",l->second->name.c_str());
+    CONSOLE_BRIDGE_logDebug("urdfdom: exporting link [%s]\n",l->second->name.c_str());
     exportLink(*(l->second), robot);
   }
   	
   for (std::map<std::string, JointSharedPtr>::const_iterator j=model.joints_.begin(); j!=model.joints_.end(); j++)  
   {
-    logDebug("urdfdom: exporting joint [%s]\n",j->second->name.c_str());
+    CONSOLE_BRIDGE_logDebug("urdfdom: exporting joint [%s]\n",j->second->name.c_str());
     exportJoint(*(j->second), robot);
   }
 

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -51,7 +51,7 @@ ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
     std::ifstream stream( path.c_str() );
     if (!stream)
     {
-      logError(("File " + path + " does not exist").c_str());
+      CONSOLE_BRIDGE_logError(("File " + path + " does not exist").c_str());
       return ModelInterfaceSharedPtr();
     }
 
@@ -69,7 +69,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   xml_doc.Parse(xml_string.c_str());
   if (xml_doc.Error())
   {
-    logError(xml_doc.ErrorDesc());
+    CONSOLE_BRIDGE_logError(xml_doc.ErrorDesc());
     xml_doc.ClearError();
     model.reset();
     return model;
@@ -78,7 +78,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   TiXmlElement *robot_xml = xml_doc.FirstChildElement("robot");
   if (!robot_xml)
   {
-    logError("Could not find the 'robot' element in the xml file");
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file");
     model.reset();
     return model;
   }
@@ -87,7 +87,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   const char *name = robot_xml->Attribute("name");
   if (!name)
   {
-    logError("No name given for the robot.");
+    CONSOLE_BRIDGE_logError("No name given for the robot.");
     model.reset();
     return model;
   }
@@ -103,7 +103,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       parseMaterial(*material, material_xml, false); // material needs to be fully defined here
       if (model->getMaterial(material->name))
       {
-        logError("material '%s' is not unique.", material->name.c_str());
+        CONSOLE_BRIDGE_logError("material '%s' is not unique.", material->name.c_str());
         material.reset();
         model.reset();
         return model;
@@ -115,7 +115,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       }
     }
     catch (ParseError &/*e*/) {
-      logError("material xml is not initialized correctly");
+      CONSOLE_BRIDGE_logError("material xml is not initialized correctly");
       material.reset();
       model.reset();
       return model;
@@ -132,7 +132,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       parseLink(*link, link_xml);
       if (model->getLink(link->name))
       {
-        logError("link '%s' is not unique.", link->name.c_str());
+        CONSOLE_BRIDGE_logError("link '%s' is not unique.", link->name.c_str());
         model.reset();
         return model;
       }
@@ -158,7 +158,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
               }
               else
               {
-                logError("link '%s' material '%s' undefined.", link->name.c_str(),link->visual->material_name.c_str());
+                CONSOLE_BRIDGE_logError("link '%s' material '%s' undefined.", link->name.c_str(),link->visual->material_name.c_str());
                 model.reset();
                 return model;
               }
@@ -171,13 +171,13 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       }
     }
     catch (ParseError &/*e*/) {
-      logError("link xml is not initialized correctly");
+      CONSOLE_BRIDGE_logError("link xml is not initialized correctly");
       model.reset();
       return model;
     }
   }
   if (model->links_.empty()){
-    logError("No link elements found in urdf file");
+    CONSOLE_BRIDGE_logError("No link elements found in urdf file");
     model.reset();
     return model;
   }
@@ -192,7 +192,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     {
       if (model->getJoint(joint->name))
       {
-        logError("joint '%s' is not unique.", joint->name.c_str());
+        CONSOLE_BRIDGE_logError("joint '%s' is not unique.", joint->name.c_str());
         model.reset();
         return model;
       }
@@ -204,7 +204,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     }
     else
     {
-      logError("joint xml is not initialized correctly");
+      CONSOLE_BRIDGE_logError("joint xml is not initialized correctly");
       model.reset();
       return model;
     }
@@ -223,7 +223,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   }
   catch(ParseError &e)
   {
-    logError("Failed to build tree: %s", e.what());
+    CONSOLE_BRIDGE_logError("Failed to build tree: %s", e.what());
     model.reset();
     return model;
   }
@@ -235,7 +235,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   }
   catch(ParseError &e)
   {
-    logError("Failed to find root link: %s", e.what());
+    CONSOLE_BRIDGE_logError("Failed to find root link: %s", e.what());
     model.reset();
     return model;
   }

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -100,7 +100,7 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
         pose.position.init(xyz_str);
       }
       catch (ParseError &e) {
-        logError(e.what());
+        CONSOLE_BRIDGE_logError(e.what());
         return false;
       }
     }
@@ -112,7 +112,7 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
         pose.rotation.init(rpy_str);
       }
       catch (ParseError &e) {
-        logError(e.what());
+        CONSOLE_BRIDGE_logError(e.what());
         return false;
       }
     }

--- a/urdf_parser/src/twist.cpp
+++ b/urdf_parser/src/twist.cpp
@@ -58,7 +58,7 @@ bool parseTwist(Twist &twist, TiXmlElement* xml)
       }
       catch (ParseError &e) {
         twist.linear.clear();
-        logError("Malformed linear string [%s]: %s", linear_char, e.what());
+        CONSOLE_BRIDGE_logError("Malformed linear string [%s]: %s", linear_char, e.what());
         return false;
       }
     }
@@ -71,7 +71,7 @@ bool parseTwist(Twist &twist, TiXmlElement* xml)
       }
       catch (ParseError &e) {
         twist.angular.clear();
-        logError("Malformed angular [%s]: %s", angular_char, e.what());
+        CONSOLE_BRIDGE_logError("Malformed angular [%s]: %s", angular_char, e.what());
         return false;
       }
     }

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -52,7 +52,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
   const char *name_char = config->Attribute("name");
   if (!name_char)
   {
-    logError("No name given for the model_state.");
+    CONSOLE_BRIDGE_logError("No name given for the model_state.");
     return false;
   }
   ms.name = std::string(name_char);
@@ -65,7 +65,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
       ms.time_stamp.set(sec);
     }
     catch (boost::bad_lexical_cast &e) {
-      logError("Parsing time stamp [%s] failed: %s", time_stamp_char, e.what());
+      CONSOLE_BRIDGE_logError("Parsing time stamp [%s] failed: %s", time_stamp_char, e.what());
       return false;
     }
   }
@@ -81,7 +81,7 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
       joint_state->joint = std::string(joint_char);
     else
     {
-      logError("No joint name given for the model_state.");
+      CONSOLE_BRIDGE_logError("No joint name given for the model_state.");
       return false;
     }
     

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -64,13 +64,13 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Camera image width [%s] is not a valid int: %s", width_char, e.what());
+        CONSOLE_BRIDGE_logError("Camera image width [%s] is not a valid int: %s", width_char, e.what());
         return false;
       }
     }
     else
     {
-      logError("Camera sensor needs an image width attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image width attribute");
       return false;
     }
 
@@ -83,13 +83,13 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Camera image height [%s] is not a valid int: %s", height_char, e.what());
+        CONSOLE_BRIDGE_logError("Camera image height [%s] is not a valid int: %s", height_char, e.what());
         return false;
       }
     }
     else
     {
-      logError("Camera sensor needs an image height attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image height attribute");
       return false;
     }
 
@@ -98,7 +98,7 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       camera.format = std::string(format_char);
     else
     {
-      logError("Camera sensor needs an image format attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image format attribute");
       return false;
     }    
 
@@ -111,13 +111,13 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Camera image hfov [%s] is not a valid float: %s", hfov_char, e.what());
+        CONSOLE_BRIDGE_logError("Camera image hfov [%s] is not a valid float: %s", hfov_char, e.what());
         return false;
       }
     }
     else
     {
-      logError("Camera sensor needs an image hfov attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image hfov attribute");
       return false;
     }
 
@@ -130,13 +130,13 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Camera image near [%s] is not a valid float: %s", near_char, e.what());
+        CONSOLE_BRIDGE_logError("Camera image near [%s] is not a valid float: %s", near_char, e.what());
         return false;
       }
     }
     else
     {
-      logError("Camera sensor needs an image near attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image near attribute");
       return false;
     }
 
@@ -149,20 +149,20 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Camera image far [%s] is not a valid float: %s", far_char, e.what());
+        CONSOLE_BRIDGE_logError("Camera image far [%s] is not a valid float: %s", far_char, e.what());
         return false;
       }
     }
     else
     {
-      logError("Camera sensor needs an image far attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor needs an image far attribute");
       return false;
     }
     
   }
   else
   {
-    logError("Camera sensor has no <image> element");
+    CONSOLE_BRIDGE_logError("Camera sensor has no <image> element");
     return false;
   }
   return true;
@@ -185,7 +185,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray horizontal samples [%s] is not a valid float: %s", samples_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray horizontal samples [%s] is not a valid float: %s", samples_char, e.what());
         return false;
       }
     }
@@ -199,7 +199,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray horizontal resolution [%s] is not a valid float: %s", resolution_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray horizontal resolution [%s] is not a valid float: %s", resolution_char, e.what());
         return false;
       }
     }   
@@ -213,7 +213,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray horizontal min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray horizontal min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
         return false;
       }
     }
@@ -227,7 +227,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray horizontal max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray horizontal max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
         return false;
       }
     }
@@ -245,7 +245,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray vertical samples [%s] is not a valid float: %s", samples_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray vertical samples [%s] is not a valid float: %s", samples_char, e.what());
         return false;
       }
     }
@@ -259,7 +259,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray vertical resolution [%s] is not a valid float: %s", resolution_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray vertical resolution [%s] is not a valid float: %s", resolution_char, e.what());
         return false;
       }
     }   
@@ -273,7 +273,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray vertical min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray vertical min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
         return false;
       }
     }
@@ -287,7 +287,7 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Ray vertical max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
+        CONSOLE_BRIDGE_logError("Ray vertical max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
         return false;
       }
     }
@@ -319,7 +319,7 @@ VisualSensorSharedPtr parseVisualSensor(TiXmlElement *g)
   }
   else
   {
-    logError("No know sensor types [camera|ray] defined in <sensor> block");
+    CONSOLE_BRIDGE_logError("No know sensor types [camera|ray] defined in <sensor> block");
   }
   return visual_sensor;
 }
@@ -332,7 +332,7 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   const char *name_char = config->Attribute("name");
   if (!name_char)
   {
-    logError("No name given for the sensor.");
+    CONSOLE_BRIDGE_logError("No name given for the sensor.");
     return false;
   }
   sensor.name = std::string(name_char);
@@ -341,7 +341,7 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   const char *parent_link_name_char = config->Attribute("parent_link_name");
   if (!parent_link_name_char)
   {
-    logError("No parent_link_name given for the sensor.");
+    CONSOLE_BRIDGE_logError("No parent_link_name given for the sensor.");
     return false;
   }
   sensor.parent_link_name = std::string(parent_link_name_char);


### PR DESCRIPTION
Require the latest version of console_bridge and use the new namespaced macros to prevent deprecation warnings.