### PR TITLE
Update travis CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-language: cpp
+sudo: required
+dist: trusty
+# Force travis to use its minimal image with default Python settings
+language: generic
 compiler:
   - clang
   - gcc
 script: "./.travis/build"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libtinyxml-dev
+  - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libboost-test-dev libtinyxml-dev python-yaml
 matrix:
   allow_failures:
     - compiler: clang

--- a/.travis/build
+++ b/.travis/build
@@ -4,7 +4,6 @@ set -ev
 # Directories.
 root_dir=`pwd`
 build_dir="$root_dir/_travis/build"
-install_dir="$root_dir/_travis/install"
 console_bridge_dir="$build_dir/console_bridge"
 urdfdom_headers_dir="$build_dir/urdfdom_headers"
 
@@ -12,34 +11,29 @@ urdfdom_headers_dir="$build_dir/urdfdom_headers"
 git_clone="git clone --quiet --recursive"
 
 # Create layout.
-rm -rf "$build_dir" "$install_dir"
+rm -rf "$build_dir"
 mkdir -p "$build_dir"
-mkdir -p "$install_dir"
-
-# Setup environment variables.
-export LD_LIBRARY_PATH="$install_dir/lib:$LD_LIBRARY_PATH"
-export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # Retrieve console_bridge
 echo "--> Compiling console_bridge"
 cd "$build_dir"
 $git_clone "git://github.com/ros/console_bridge.git"
 cd "$console_bridge_dir"
-cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
-make install
+cmake .
+sudo make install
 
 # Retrieve urdfdom_headers
 echo "--> Compiling urdfdom_headers"
 cd "$build_dir"
 $git_clone "git://github.com/ros/urdfdom_headers.git"
 cd "$urdfdom_headers_dir"
-cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
-make install
+cmake .
+sudo make install
 
 # Compile
 echo "--> Compiling urdfdom"
 cd "$root_dir"
-cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"
+cmake .
 make
-#make check
-make install
+make test ARGS="-VV"
+sudo make install


### PR DESCRIPTION
install libboost-test-dev, python-yaml
install to /usr with sudo
make test with verbose
language generic to fix python

@tfoote can you enable travis for this repository

It's [passing on my fork](https://travis-ci.org/scpeters/urdfdom/builds/103487994)