### PR TITLE
urdf_parser: fix dll macro

### DIFF
--- a/urdf_parser/include/urdf_parser/exportdecl.h
+++ b/urdf_parser/include/urdf_parser/exportdecl.h
@@ -74,7 +74,7 @@
 # else
 // Depending on whether one is building or using the
 // library define DLLAPI to import or export.
-#  ifdef console_bridge_EXPORTS
+#  ifdef URDFDOM_EXPORTS
 #   define URDFDOM_DLLAPI URDFDOM_DLLEXPORT
 #  else
 #   define URDFDOM_DLLAPI URDFDOM_DLLIMPORT


### PR DESCRIPTION
Bad copy and paste led to `console_bridge_EXPORTS` being used instead of `URDFDOM_EXPORTS` but it is fixed here. This was mentioned in #64.