### PR TITLE
Add/remove boost headers from source files

### DIFF
--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -34,7 +34,6 @@
 
 /* Author: Wim Meeussen */
 
-#include <boost/algorithm/string.hpp>
 #include <vector>
 #include "urdf_parser/urdf_parser.h"
 #include <console_bridge/console.h>

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -38,7 +38,6 @@
 #include <urdf_model/pose.h>
 #include <fstream>
 #include <sstream>
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <console_bridge/console.h>
 #include <tinyxml.h>

--- a/urdf_parser/src/twist.cpp
+++ b/urdf_parser/src/twist.cpp
@@ -38,7 +38,6 @@
 #include <urdf_model/twist.h>
 #include <fstream>
 #include <sstream>
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <tinyxml.h>
 #include <console_bridge/console.h>

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -38,6 +38,7 @@
 #include <urdf_model_state/model_state.h>
 #include <fstream>
 #include <sstream>
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <tinyxml.h>

--- a/urdf_parser/src/world.cpp
+++ b/urdf_parser/src/world.cpp
@@ -40,7 +40,6 @@
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <sstream>
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <tinyxml.h>
 #include <console_bridge/console.h>


### PR DESCRIPTION
Add missing `boost/algorithm/string.hpp` include and remove unused `boost/lexical_cast.hpp` includes.