### PR TITLE
cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,21 @@ endif()
 set(PKG_NAME ${PROJECT_NAME})
 set(PKG_LIBRARIES urdfdom_sensor urdfdom_model_state urdfdom_model urdfdom_world)
 set(PKG_DEPENDS urdfdom_headers console_bridge)
-set(cmake_conf_file "cmake/urdfdom-config.cmake")
+set(cmake_conf_file "cmake/${PROJECT_NAME}-config.cmake")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${cmake_conf_file}.in" "${CMAKE_BINARY_DIR}/${cmake_conf_file}" @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/${cmake_conf_file}
+set(cmake_conf_version_file "${PROJECT_NAME}-config-version.cmake")
+# Use write_basic_package_version_file to generate a ConfigVersion file that
+# allow users of gazebo to specify the API or version to depend on
+# TODO: keep this instruction until deprecate Ubuntu/Precise and update with
+# https://github.com/Kitware/CMake/blob/v2.8.8/Modules/CMakePackageConfigHelpers.cmake
+include(WriteBasicConfigVersionFile)
+write_basic_config_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${cmake_conf_version_file}
+  VERSION "${URDF_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+install(FILES
+  "${CMAKE_BINARY_DIR}/${cmake_conf_file}"
+  "${CMAKE_BINARY_DIR}/${cmake_conf_version_file}"
   DESTINATION ${CMAKE_CONFIG_INSTALL_DIR} COMPONENT cmake)
 
 # Make the package config file

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -1,20 +1,20 @@
 include_directories(include)
 
-add_library(urdfdom_world SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
-target_link_libraries(urdfdom_world ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
-set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
-
 add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
 target_link_libraries(urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
 set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
-target_link_libraries(urdfdom_sensor urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(urdfdom_sensor urdfdom_model)
 set_target_properties(urdfdom_sensor PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 add_library(urdfdom_model_state SHARED src/urdf_model_state.cpp src/twist.cpp)
 target_link_libraries(urdfdom_model_state ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
 set_target_properties(urdfdom_model_state PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
+
+add_library(urdfdom_world SHARED src/world.cpp)
+target_link_libraries(urdfdom_world urdfdom_model)
+set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 # --------------------------------
 

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -1,6 +1,10 @@
-include_directories(include)
+include_directories(BEFORE include)
 
-add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
+add_library(urdfdom_model SHARED
+  src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp
+  include/urdf_parser/exportdecl.h include/urdf_parser/urdf_parser.h
+  include/urdf_parser/joint.h include/urdf_parser/link.h include/urdf_parser/pose.h
+)
 target_link_libraries(urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
 set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 

--- a/urdf_parser/include/urdf_parser/joint.h
+++ b/urdf_parser/include/urdf_parser/joint.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,50 +32,18 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: John Hsu */
+#ifndef URDF_PARSER_JOINT_H
+#define URDF_PARSER_JOINT_H
 
-
-#include <urdf_model/twist.h>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
+#include <urdf_model/joint.h>
 #include <tinyxml.h>
-#include <console_bridge/console.h>
 
-namespace urdf{
+namespace urdf {
 
-bool parseTwist(Twist &twist, TiXmlElement* xml)
-{
-  twist.clear();
-  if (xml)
-  {
-    const char* linear_char = xml->Attribute("linear");
-    if (linear_char != NULL)
-    {
-      try {
-        twist.linear.init(linear_char);
-      }
-      catch (ParseError &e) {
-        twist.linear.clear();
-        CONSOLE_BRIDGE_logError("Malformed linear string [%s]: %s", linear_char, e.what());
-        return false;
-      }
-    }
+bool parseJoint(Joint &joint, TiXmlElement *config);
 
-    const char* angular_char = xml->Attribute("angular");
-    if (angular_char != NULL)
-    {
-      try {
-        twist.angular.init(angular_char);
-      }
-      catch (ParseError &e) {
-        twist.angular.clear();
-        CONSOLE_BRIDGE_logError("Malformed angular [%s]: %s", angular_char, e.what());
-        return false;
-      }
-    }
-  }
-  return true;
-}
+bool exportJoint(Joint &joint, TiXmlElement *config);
 
 }
+
+#endif

--- a/urdf_parser/include/urdf_parser/link.h
+++ b/urdf_parser/include/urdf_parser/link.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,50 +32,44 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: John Hsu */
+#ifndef URDF_PARSER_LINK_H
+#define URDF_PARSER_LINK_H
 
-
-#include <urdf_model/twist.h>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
+#include <urdf_model/link.h>
 #include <tinyxml.h>
-#include <console_bridge/console.h>
+#include "exportdecl.h"
 
-namespace urdf{
+namespace urdf {
 
-bool parseTwist(Twist &twist, TiXmlElement* xml)
-{
-  twist.clear();
-  if (xml)
-  {
-    const char* linear_char = xml->Attribute("linear");
-    if (linear_char != NULL)
-    {
-      try {
-        twist.linear.init(linear_char);
-      }
-      catch (ParseError &e) {
-        twist.linear.clear();
-        CONSOLE_BRIDGE_logError("Malformed linear string [%s]: %s", linear_char, e.what());
-        return false;
-      }
-    }
+URDFDOM_DLLAPI bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok);
 
-    const char* angular_char = xml->Attribute("angular");
-    if (angular_char != NULL)
-    {
-      try {
-        twist.angular.init(angular_char);
-      }
-      catch (ParseError &e) {
-        twist.angular.clear();
-        CONSOLE_BRIDGE_logError("Malformed angular [%s]: %s", angular_char, e.what());
-        return false;
-      }
-    }
-  }
-  return true;
-}
+URDFDOM_DLLAPI bool parseSphere(Sphere &s, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseBox(Box &b, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseCylinder(Cylinder &y, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseMesh(Mesh &m, TiXmlElement *c);
+URDFDOM_DLLAPI GeometrySharedPtr parseGeometry(TiXmlElement *g);
+
+URDFDOM_DLLAPI bool parseInertial(Inertial &i, TiXmlElement *config);
+URDFDOM_DLLAPI bool parseVisual(Visual &vis, TiXmlElement *config);
+URDFDOM_DLLAPI bool parseCollision(Collision &col, TiXmlElement* config);
+
+URDFDOM_DLLAPI bool parseLink(Link &link, TiXmlElement *config);
+
+
+URDFDOM_DLLAPI bool exportMaterial(Material &material, TiXmlElement *config);
+
+URDFDOM_DLLAPI bool exportSphere(Sphere &s, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportBox(Box &b, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportCylinder(Cylinder &y, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportMesh(Mesh &m, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml);
+
+URDFDOM_DLLAPI bool exportInertial(Inertial &i, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportVisual(Visual &vis, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportCollision(Collision &col, TiXmlElement* xml);
+
+URDFDOM_DLLAPI bool exportLink(Link &link, TiXmlElement *config);
 
 }
+
+#endif

--- a/urdf_parser/include/urdf_parser/pose.h
+++ b/urdf_parser/include/urdf_parser/pose.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,50 +32,29 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: John Hsu */
+#ifndef URDF_PARSER_POSE_H
+#define URDF_PARSER_POSE_H
 
-
-#include <urdf_model/twist.h>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
+#include <urdf_model/pose.h>
+#include <urdf_model/color.h>
 #include <tinyxml.h>
-#include <console_bridge/console.h>
+#include "exportdecl.h"
 
-namespace urdf{
+namespace urdf_export_helpers {
 
-bool parseTwist(Twist &twist, TiXmlElement* xml)
-{
-  twist.clear();
-  if (xml)
-  {
-    const char* linear_char = xml->Attribute("linear");
-    if (linear_char != NULL)
-    {
-      try {
-        twist.linear.init(linear_char);
-      }
-      catch (ParseError &e) {
-        twist.linear.clear();
-        CONSOLE_BRIDGE_logError("Malformed linear string [%s]: %s", linear_char, e.what());
-        return false;
-      }
-    }
-
-    const char* angular_char = xml->Attribute("angular");
-    if (angular_char != NULL)
-    {
-      try {
-        twist.angular.init(angular_char);
-      }
-      catch (ParseError &e) {
-        twist.angular.clear();
-        CONSOLE_BRIDGE_logError("Malformed angular [%s]: %s", angular_char, e.what());
-        return false;
-      }
-    }
-  }
-  return true;
-}
+URDFDOM_DLLAPI std::string values2str(unsigned int count, const double *values, double (*conv)(double) = NULL);
+URDFDOM_DLLAPI std::string values2str(urdf::Vector3 vec);
+URDFDOM_DLLAPI std::string values2str(urdf::Rotation rot);
+URDFDOM_DLLAPI std::string values2str(urdf::Color c);
+URDFDOM_DLLAPI std::string values2str(double d);
 
 }
+
+namespace urdf {
+
+URDFDOM_DLLAPI bool parsePose(Pose&, TiXmlElement*);
+URDFDOM_DLLAPI bool exportPose(Pose &pose, TiXmlElement* xml);
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/sensor.h
+++ b/urdf_parser/include/urdf_parser/sensor.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,50 +32,16 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: John Hsu */
+#ifndef URDF_PARSER_SENSOR_H
+#define URDF_PARSER_SENSOR_H
 
-
-#include <urdf_model/twist.h>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
+#include <urdf_sensor/sensor.h>
 #include <tinyxml.h>
-#include <console_bridge/console.h>
 
-namespace urdf{
+namespace urdf {
 
-bool parseTwist(Twist &twist, TiXmlElement* xml)
-{
-  twist.clear();
-  if (xml)
-  {
-    const char* linear_char = xml->Attribute("linear");
-    if (linear_char != NULL)
-    {
-      try {
-        twist.linear.init(linear_char);
-      }
-      catch (ParseError &e) {
-        twist.linear.clear();
-        CONSOLE_BRIDGE_logError("Malformed linear string [%s]: %s", linear_char, e.what());
-        return false;
-      }
-    }
-
-    const char* angular_char = xml->Attribute("angular");
-    if (angular_char != NULL)
-    {
-      try {
-        twist.angular.init(angular_char);
-      }
-      catch (ParseError &e) {
-        twist.angular.clear();
-        CONSOLE_BRIDGE_logError("Malformed angular [%s]: %s", angular_char, e.what());
-        return false;
-      }
-    }
-  }
-  return true;
-}
+bool parseSensor(Sensor &sensor, TiXmlElement* config);
 
 }
+
+#endif

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -38,31 +38,21 @@
 #define URDF_PARSER_URDF_PARSER_H
 
 #include <string>
-#include <map>
 #include <tinyxml.h>
 #include <urdf_model/model.h>
 #include <urdf_model/color.h>
 #include <urdf_world/types.h>
 
 #include "exportdecl.h"
+#include "pose.h"
 
-namespace urdf_export_helpers {
-
-URDFDOM_DLLAPI std::string values2str(unsigned int count, const double *values, double (*conv)(double) = NULL);
-URDFDOM_DLLAPI std::string values2str(urdf::Vector3 vec);
-URDFDOM_DLLAPI std::string values2str(urdf::Rotation rot);
-URDFDOM_DLLAPI std::string values2str(urdf::Color c);
-URDFDOM_DLLAPI std::string values2str(double d);
-
-}
-
-namespace urdf{
+namespace urdf {
 
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDF(const std::string &xml_string);
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDFFile(const std::string &path);
   URDFDOM_DLLAPI TiXmlDocument*  exportURDF(ModelInterfaceSharedPtr &model);
   URDFDOM_DLLAPI TiXmlDocument*  exportURDF(const ModelInterface &model);
-  URDFDOM_DLLAPI bool parsePose(Pose&, TiXmlElement*);
+
 }
 
 #endif

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -41,11 +41,11 @@
 #include <urdf_model/joint.h>
 #include <console_bridge/console.h>
 #include <tinyxml.h>
-#include <urdf_parser/urdf_parser.h>
+#include "urdf_parser/urdf_parser.h"
+#include "urdf_parser/joint.h"
+#include "urdf_parser/pose.h"
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
 {
@@ -521,10 +521,6 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
 
   return true;
 }
-
-
-/* exports */
-bool exportPose(Pose &pose, TiXmlElement* xml);
 
 bool exportJointDynamics(JointDynamics &jd, TiXmlElement* xml)
 {

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -35,8 +35,9 @@
 /* Author: Wim Meeussen */
 
 
-#include <urdf_parser/urdf_parser.h>
-#include <urdf_model/link.h>
+#include "urdf_parser/urdf_parser.h"
+#include "urdf_parser/pose.h"
+#include "urdf_parser/link.h"
 #include <fstream>
 #include <locale>
 #include <sstream>
@@ -49,8 +50,6 @@
 #include <console_bridge/console.h>
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok)
 {
@@ -484,9 +483,6 @@ bool parseLink(Link &link, TiXmlElement* config)
 
   return true;
 }
-
-/* exports */
-bool exportPose(Pose &pose, TiXmlElement* xml);
 
 bool exportMaterial(Material &material, TiXmlElement *xml)
 {

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -36,14 +36,13 @@
 
 #include <vector>
 #include "urdf_parser/urdf_parser.h"
+#include "urdf_parser/pose.h"
+#include "urdf_parser/link.h"
+#include "urdf_parser/joint.h"
 #include <console_bridge/console.h>
 #include <fstream>
 
 namespace urdf{
-
-bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok);
-bool parseLink(Link &link, TiXmlElement *config);
-bool parseJoint(Joint &joint, TiXmlElement *config);
 
 ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
 {
@@ -55,7 +54,7 @@ ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
     }
 
     std::string xml_str((std::istreambuf_iterator<char>(stream)),
-	                     std::istreambuf_iterator<char>());
+                        std::istreambuf_iterator<char>());
     return urdf::parseURDF( xml_str );
 }
 
@@ -252,9 +251,6 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   return model;
 }
 
-bool exportMaterial(Material &material, TiXmlElement *config);
-bool exportLink(Link &link, TiXmlElement *config);
-bool exportJoint(Joint &joint, TiXmlElement *config);
 TiXmlDocument*  exportURDF(const ModelInterface &model)
 {
   TiXmlDocument *doc = new TiXmlDocument();

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -35,13 +35,13 @@
 /* Author: Wim Meeussen, John Hsu */
 
 
-#include <urdf_model/pose.h>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <console_bridge/console.h>
 #include <tinyxml.h>
 #include <urdf_parser/urdf_parser.h>
+#include <urdf_parser/pose.h>
 
 namespace urdf_export_helpers {
 

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -332,11 +332,12 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   }
   sensor.name = std::string(name_char);
 
-  // parse parent_link_name
-  const char *parent_link_name_char = config->Attribute("parent_link_name");
+  // parse parent link name
+  TiXmlElement *parent_xml = config->FirstChildElement("parent");
+  const char *parent_link_name_char = parent_xml ? parent_xml->Attribute("link") : NULL;
   if (!parent_link_name_char)
   {
-    CONSOLE_BRIDGE_logError("No parent_link_name given for the sensor.");
+    CONSOLE_BRIDGE_logError("No parent link name given for the sensor.");
     return false;
   }
   sensor.parent_link_name = std::string(parent_link_name_char);

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -44,10 +44,9 @@
 #include <algorithm>
 #include <tinyxml.h>
 #include <console_bridge/console.h>
+#include "urdf_parser/pose.h"
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseCamera(Camera &camera, TiXmlElement* config)
 {
@@ -319,7 +318,6 @@ VisualSensorSharedPtr parseVisualSensor(TiXmlElement *g)
   return visual_sensor;
 }
 
-
 bool parseSensor(Sensor &sensor, TiXmlElement* config)
 {
   sensor.clear();
@@ -354,7 +352,6 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   sensor.sensor = parseVisualSensor(config);
   return true;
 }
-
 
 }
 

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -35,12 +35,14 @@ foreach(GTEST_SOURCE_file ${tests})
   endif()
 
   add_test(NAME    ${BINARY_NAME}
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
   set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240 ENVIRONMENT LC_ALL=C)
   
   add_test(NAME    ${BINARY_NAME}_locale
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}_locale.xml)
 

--- a/urdf_parser/test/basic.urdf
+++ b/urdf_parser/test/basic.urdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="robot" version="1.0" xmlns="http://www.ros.org">
+  <link name="link1"/>
+  <link name="link2"/>
+  <joint name="joint1" type="floating">
+    <parent link="link1" />
+    <child link="link2" />
+  </joint>
+  <sensor name="camera1" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <camera>
+      <image width="640" height="480" hfov="1.5708" format="RGB8" near="0.01" far="50.0"/>
+    </camera>
+  </sensor>
+  <sensor name="ray1" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <ray>
+      <horizontal samples="100" resolution="1" min_angle="-1.5708" max_angle="1.5708"/>
+      <vertical samples="1" resolution="1" min_angle="0" max_angle="0"/>
+    </ray>
+  </sensor>
+</robot>

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <urdf_parser/urdf_parser.h>
 #include <iostream>
 #include <iomanip>
 #include <cmath>
@@ -341,4 +342,39 @@ int main(int argc, char **argv)
   setlocale(LC_ALL, "");
 
   return RUN_ALL_TESTS();
+}
+
+TEST(URDF_UNIT_TEST, test_basic_parsing)
+{
+  urdf::ModelInterfaceSharedPtr model = urdf::parseURDFFile("basic.urdf");
+  ASSERT_TRUE((bool)model);
+  EXPECT_TRUE((bool)model->getLink("link1"));
+  EXPECT_TRUE((bool)model->getLink("link2"));
+  EXPECT_TRUE((bool)model->getJoint("joint1"));
+}
+
+TEST(URDF_UNIT_TEST, test_only_consider_top_level)
+{
+  TiXmlDocument doc("basic.urdf");
+  ASSERT_TRUE(doc.LoadFile());
+
+  // move child elements of robot tag into a dummy tag (which should be ignored during parsing)
+  TiXmlElement *robot = doc.FirstChildElement("robot");
+  TiXmlElement *dummy = new TiXmlElement("dummy");
+  for(TiXmlNode *child = robot->FirstChild(); child; child = child->NextSibling())
+    dummy->InsertEndChild(*child);
+  robot->Clear();
+  robot->InsertEndChild(*dummy);
+  // we need a link at least:
+  TiXmlElement *link = robot->InsertEndChild(TiXmlElement("link"))->ToElement();
+  link->SetAttribute("name", "link");
+
+  // serialize and parse again
+  std::stringstream oss; oss << doc;
+  urdf::ModelInterfaceSharedPtr model = urdf::parseURDF(oss.str());
+  ASSERT_TRUE((bool)model);
+  EXPECT_TRUE((bool)model->getLink("link"));
+  EXPECT_TRUE(!model->getLink("link1"));
+  EXPECT_TRUE(!model->getLink("link2"));
+  EXPECT_TRUE(!model->getJoint("joint1"));
 }


### PR DESCRIPTION
Before starting to rework the sensor parsing, I cleaned the code base a little bit. For me, it was hard to navigate the code, because function declarations were spread (and repeated) across the cpp files, So I moved them into separate header files. Also, I made some more functions visible for further re-use.

IMHO there were also some minor issues:
- liburdfdom_world linked the same symbols as liburdf_model. I guess it would be better to link against liburdf_model in that case.
- include order was wrong: the local include folder should precede the include folders of dependencies. Otherwise, when installing urdfdom_headers and urdfdom into same location, the headers from a previous urdfdom install would be used.
- Parsing of parent link name didn't comply to the [spec](http://wiki.ros.org/urdf/XML/sensor) requiring a parent tag.
