### PR TITLE
refactoring sensor parsing

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -58,7 +58,8 @@ add_urdfdom_library(
   LIBNAME
     urdfdom_sensor
   SOURCES
-    src/urdf_sensor.cpp
+    src/sensor_parser.cpp
+    src/visual_sensor_parsers.cpp
   LINK
     urdfdom_model)
 

--- a/urdf_parser/include/urdf_parser/joint.h
+++ b/urdf_parser/include/urdf_parser/joint.h
@@ -1,0 +1,49 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef URDF_PARSER_JOINT_H
+#define URDF_PARSER_JOINT_H
+
+#include <urdf_model/joint.h>
+#include <tinyxml.h>
+
+namespace urdf {
+
+bool parseJoint(Joint &joint, TiXmlElement *config);
+
+bool exportJoint(Joint &joint, TiXmlElement *config);
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/link.h
+++ b/urdf_parser/include/urdf_parser/link.h
@@ -1,0 +1,75 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef URDF_PARSER_LINK_H
+#define URDF_PARSER_LINK_H
+
+#include <urdf_model/link.h>
+#include <tinyxml.h>
+#include "exportdecl.h"
+
+namespace urdf {
+
+URDFDOM_DLLAPI bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok);
+
+URDFDOM_DLLAPI bool parseSphere(Sphere &s, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseBox(Box &b, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseCylinder(Cylinder &y, TiXmlElement *c);
+URDFDOM_DLLAPI bool parseMesh(Mesh &m, TiXmlElement *c);
+URDFDOM_DLLAPI GeometrySharedPtr parseGeometry(TiXmlElement *g);
+
+URDFDOM_DLLAPI bool parseInertial(Inertial &i, TiXmlElement *config);
+URDFDOM_DLLAPI bool parseVisual(Visual &vis, TiXmlElement *config);
+URDFDOM_DLLAPI bool parseCollision(Collision &col, TiXmlElement* config);
+
+URDFDOM_DLLAPI bool parseLink(Link &link, TiXmlElement *config);
+
+
+URDFDOM_DLLAPI bool exportMaterial(Material &material, TiXmlElement *config);
+
+URDFDOM_DLLAPI bool exportSphere(Sphere &s, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportBox(Box &b, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportCylinder(Cylinder &y, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportMesh(Mesh &m, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportGeometry(GeometrySharedPtr &geom, TiXmlElement *xml);
+
+URDFDOM_DLLAPI bool exportInertial(Inertial &i, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportVisual(Visual &vis, TiXmlElement *xml);
+URDFDOM_DLLAPI bool exportCollision(Collision &col, TiXmlElement* xml);
+
+URDFDOM_DLLAPI bool exportLink(Link &link, TiXmlElement *config);
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/pose.h
+++ b/urdf_parser/include/urdf_parser/pose.h
@@ -1,0 +1,60 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef URDF_PARSER_POSE_H
+#define URDF_PARSER_POSE_H
+
+#include <urdf_model/pose.h>
+#include <urdf_model/color.h>
+#include <tinyxml.h>
+#include "exportdecl.h"
+
+namespace urdf_export_helpers {
+
+URDFDOM_DLLAPI std::string values2str(unsigned int count, const double *values, double (*conv)(double) = NULL);
+URDFDOM_DLLAPI std::string values2str(urdf::Vector3 vec);
+URDFDOM_DLLAPI std::string values2str(urdf::Rotation rot);
+URDFDOM_DLLAPI std::string values2str(urdf::Color c);
+URDFDOM_DLLAPI std::string values2str(double d);
+
+}
+
+namespace urdf {
+
+URDFDOM_DLLAPI bool parsePose(Pose&, TiXmlElement*);
+URDFDOM_DLLAPI bool exportPose(Pose &pose, TiXmlElement* xml);
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/sensor.h
+++ b/urdf_parser/include/urdf_parser/sensor.h
@@ -1,0 +1,47 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef URDF_PARSER_SENSOR_H
+#define URDF_PARSER_SENSOR_H
+
+#include <urdf_sensor/sensor.h>
+#include <tinyxml.h>
+
+namespace urdf {
+
+bool parseSensor(Sensor &sensor, TiXmlElement* config);
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/sensor_parser.h
+++ b/urdf_parser/include/urdf_parser/sensor_parser.h
@@ -1,0 +1,75 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, Bielefeld University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Bielefeld University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Robert Haschke */
+
+#ifndef URDF_PARSER_URDF_SENSOR_PARSER_H
+#define URDF_PARSER_URDF_SENSOR_PARSER_H
+
+#include <string>
+#include <map>
+#include <tinyxml.h>
+#include <urdf_sensor/types.h>
+
+#include "exportdecl.h"
+
+namespace urdf {
+
+  /// API for any custom SensorParser
+  class URDFDOM_DLLAPI SensorParser {
+  public:
+    virtual ~SensorParser() = default;
+    virtual SensorBaseSharedPtr parse(TiXmlElement &sensor_element) = 0;
+  };
+  URDF_TYPEDEF_CLASS_POINTER(SensorParser);
+
+  /// map from sensor name to Sensor instance
+  using SensorMap = std::map<std::string, SensorSharedPtr>;
+  /// map from sensor type to SensorParser instance
+  using SensorParserMap = std::map<std::string, SensorParserSharedPtr>;
+
+  /** parse <sensor> tags in URDF document for which a parser exists in SensorParserMap */
+  URDFDOM_DLLAPI SensorMap parseSensors(TiXmlDocument &urdf,  const SensorParserMap &parsers);
+
+  /** convienency function to fetch a sensor with given name and type from the map */
+  template <typename T>
+  URDFDOM_DLLAPI std::shared_ptr<T> getSensor(const std::string &name, const SensorMap &sensors) {
+    SensorMap::const_iterator s = sensors.find(name);
+    if (s == sensors.end()) return std::shared_ptr<T>();
+    else return std::dynamic_pointer_cast<T>(s->second->sensor_);
+  }
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/sensor_parser.h
+++ b/urdf_parser/include/urdf_parser/sensor_parser.h
@@ -50,7 +50,7 @@ namespace urdf {
   class URDFDOM_DLLAPI SensorParser {
   public:
     virtual ~SensorParser() = default;
-    virtual SensorBaseSharedPtr parse(TiXmlElement &sensor_element) = 0;
+    virtual SensorBase* parse(TiXmlElement &sensor_element) = 0;
   };
   URDF_TYPEDEF_CLASS_POINTER(SensorParser);
 

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -46,18 +46,12 @@
 #include <urdf_model/color.h>
 #include <urdf_model/utils.h>
 #include <urdf_model_state/model_state.h>
-#include <urdf_sensor/sensor.h>
 #include <urdf_world/types.h>
 
 #include "exportdecl.h"
+#include "pose.h"
 
 namespace urdf_export_helpers {
-
-URDFDOM_DLLAPI std::string values2str(unsigned int count, const double *values, double (*conv)(double) = NULL);
-URDFDOM_DLLAPI std::string values2str(urdf::Vector3 vec);
-URDFDOM_DLLAPI std::string values2str(urdf::Rotation rot);
-URDFDOM_DLLAPI std::string values2str(urdf::Color c);
-URDFDOM_DLLAPI std::string values2str(double d);
 
 // This lives here (rather than in model.cpp) so we can run tests on it.
 class URDFVersion final
@@ -145,10 +139,6 @@ namespace urdf{
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDFFile(const std::string &path);
   URDFDOM_DLLAPI TiXmlDocument*  exportURDF(ModelInterfaceSharedPtr &model);
   URDFDOM_DLLAPI TiXmlDocument*  exportURDF(const ModelInterface &model);
-  URDFDOM_DLLAPI bool parsePose(Pose&, TiXmlElement*);
-  URDFDOM_DLLAPI bool parseCamera(Camera&, TiXmlElement*);
-  URDFDOM_DLLAPI bool parseRay(Ray&, TiXmlElement*);
-  URDFDOM_DLLAPI bool parseSensor(Sensor&, TiXmlElement*);
   URDFDOM_DLLAPI bool parseModelState(ModelState&, TiXmlElement*);
 }
 

--- a/urdf_parser/include/urdf_parser/utils.h
+++ b/urdf_parser/include/urdf_parser/utils.h
@@ -1,0 +1,88 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, CITEC, Bielefeld University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the copyright holder nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Robert Haschke */
+
+#ifndef URDF_PARSER_UTIL_H
+#define URDF_PARSER_UTIL_H
+
+#include <urdf_exception/exception.h>
+#include <urdf_model/utils.h>
+
+namespace urdf {
+
+template <typename T>
+T parseAttribute(const char* value);
+
+template<>
+inline std::string parseAttribute<std::string>(const char* value)
+{
+  return value;
+}
+
+template<>
+inline double parseAttribute<double>(const char* value)
+{
+  return strToDouble(value);
+}
+
+template<>
+inline unsigned int parseAttribute<unsigned int>(const char* value)
+{
+  return std::stoul(value);
+}
+
+template <typename T>
+T parseAttribute(const TiXmlElement &tag, const char* attr, const T* default_value=NULL)
+{
+  const char* value = tag.Attribute(attr);
+  if (!value)
+  {
+    if (default_value) return *default_value;
+    else throw ParseError(std::string("missing '") + attr + "' attribute");
+  }
+
+  try
+  {
+    return parseAttribute<T>(value);
+  }
+  catch (const std::exception &e)
+  {
+    throw ParseError(std::string("failed to parse '") + attr + "' attribute: " + e.what());
+  }
+}
+
+}
+
+#endif

--- a/urdf_parser/include/urdf_parser/visual_sensor_parsers.h
+++ b/urdf_parser/include/urdf_parser/visual_sensor_parsers.h
@@ -32,15 +32,24 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef URDF_PARSER_SENSOR_H
-#define URDF_PARSER_SENSOR_H
+/* Author: Robert Haschke */
 
-#include <urdf_sensor/sensor.h>
-#include <tinyxml.h>
+#ifndef URDF_PARSER_VISUAL_SENSOR_PARSERS_H
+#define URDF_PARSER_VISUAL_SENSOR_PARSERS_H
+
+#include "sensor_parser.h"
 
 namespace urdf {
 
-bool parseSensor(Sensor &sensor, TiXmlElement* config);
+  class URDFDOM_DLLAPI CameraParser : public SensorParser {
+  public:
+    SensorBaseSharedPtr parse(TiXmlElement &sensor_element);
+  };
+
+  class URDFDOM_DLLAPI RayParser : public SensorParser {
+  public:
+    SensorBaseSharedPtr parse(TiXmlElement &sensor_element);
+  };
 
 }
 

--- a/urdf_parser/include/urdf_parser/visual_sensor_parsers.h
+++ b/urdf_parser/include/urdf_parser/visual_sensor_parsers.h
@@ -43,12 +43,12 @@ namespace urdf {
 
   class URDFDOM_DLLAPI CameraParser : public SensorParser {
   public:
-    SensorBaseSharedPtr parse(TiXmlElement &sensor_element);
+    SensorBase* parse(TiXmlElement &sensor_element);
   };
 
   class URDFDOM_DLLAPI RayParser : public SensorParser {
   public:
-    SensorBaseSharedPtr parse(TiXmlElement &sensor_element);
+    SensorBase* parse(TiXmlElement &sensor_element);
   };
 
 }

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -42,10 +42,10 @@
 #include <console_bridge/console.h>
 #include <tinyxml.h>
 #include <urdf_parser/urdf_parser.h>
+#include <urdf_parser/joint.h>
+#include <urdf_parser/pose.h>
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
 {
@@ -521,10 +521,6 @@ bool parseJoint(Joint &joint, TiXmlElement* config)
 
   return true;
 }
-
-
-/* exports */
-bool exportPose(Pose &pose, TiXmlElement* xml);
 
 bool exportJointDynamics(JointDynamics &jd, TiXmlElement* xml)
 {

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -36,7 +36,8 @@
 
 
 #include <urdf_parser/urdf_parser.h>
-#include <urdf_model/link.h>
+#include <urdf_parser/link.h>
+#include <urdf_parser/pose.h>
 #include <fstream>
 #include <locale>
 #include <sstream>
@@ -49,8 +50,6 @@
 #include <console_bridge/console.h>
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok)
 {
@@ -484,9 +483,6 @@ bool parseLink(Link &link, TiXmlElement* config)
 
   return true;
 }
-
-/* exports */
-bool exportPose(Pose &pose, TiXmlElement* xml);
 
 bool exportMaterial(Material &material, TiXmlElement *xml)
 {

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -39,13 +39,12 @@
 #include <stdexcept>
 #include <string>
 #include "urdf_parser/urdf_parser.h"
+#include "urdf_parser/pose.h"
+#include "urdf_parser/link.h"
+#include "urdf_parser/joint.h"
 #include <console_bridge/console.h>
 
 namespace urdf{
-
-bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_ok);
-bool parseLink(Link &link, TiXmlElement *config);
-bool parseJoint(Joint &joint, TiXmlElement *config);
 
 ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
 {
@@ -269,9 +268,6 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   return model;
 }
 
-bool exportMaterial(Material &material, TiXmlElement *config);
-bool exportLink(Link &link, TiXmlElement *config);
-bool exportJoint(Joint &joint, TiXmlElement *config);
 TiXmlDocument*  exportURDF(const ModelInterface &model)
 {
   TiXmlDocument *doc = new TiXmlDocument();

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -35,13 +35,13 @@
 /* Author: Wim Meeussen, John Hsu */
 
 
-#include <urdf_model/pose.h>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <console_bridge/console.h>
 #include <tinyxml.h>
 #include <urdf_parser/urdf_parser.h>
+#include <urdf_parser/pose.h>
 
 namespace urdf_export_helpers {
 

--- a/urdf_parser/src/sensor_parser.cpp
+++ b/urdf_parser/src/sensor_parser.cpp
@@ -1,0 +1,152 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: John Hsu */
+
+
+#include "urdf_parser/sensor_parser.h"
+#include "urdf_parser/pose.h"
+#include <urdf_sensor/camera.h>
+#include <urdf_sensor/ray.h>
+
+#include <boost/lexical_cast.hpp>
+#include <console_bridge/console.h>
+
+namespace urdf {
+
+SensorBaseSharedPtr parseSensorBase(TiXmlElement *sensor_xml, const SensorParserMap &parsers)
+{
+  // find first child element that is not <parent> or <origin>
+  const char* sensor_type;
+  TiXmlElement *sensor_base_xml = sensor_xml->FirstChildElement();
+  while (sensor_base_xml) {
+    sensor_type = sensor_base_xml->Value();
+    if (strcmp(sensor_type, "parent") && strcmp(sensor_type, "origin"))
+      break;
+    sensor_base_xml = sensor_base_xml->NextSiblingElement();
+  }
+
+  if (sensor_base_xml)
+  {
+    SensorParserMap::const_iterator parser = parsers.find(sensor_type);
+    if (parser != parsers.end() && parser->second)
+    {
+      return parser->second->parse(*sensor_base_xml);
+    }
+    else
+    {
+      CONSOLE_BRIDGE_logDebug("Sensor type not handled: %s", sensor_type);
+    }
+  }
+  else
+  {
+    CONSOLE_BRIDGE_logError("No child element defining the sensor.");
+  }
+
+  return SensorBaseSharedPtr();
+}
+
+
+bool parseSensor(Sensor &sensor, TiXmlElement* config, const SensorParserMap &parsers)
+{
+  sensor.clear();
+
+  const char *name_char = config->Attribute("name");
+  if (!name_char)
+  {
+    CONSOLE_BRIDGE_logError("No name given for the sensor.");
+    return false;
+  }
+  sensor.name_ = std::string(name_char);
+
+  // parse parent link name
+  TiXmlElement *parent_xml = config->FirstChildElement("parent");
+  const char *parent_link_name_char = parent_xml ? parent_xml->Attribute("link") : NULL;
+  if (!parent_link_name_char)
+  {
+    CONSOLE_BRIDGE_logError("No parent link name given for the sensor.");
+    return false;
+  }
+  sensor.parent_link_ = std::string(parent_link_name_char);
+
+  // parse origin
+  TiXmlElement *o = config->FirstChildElement("origin");
+  if (o)
+  {
+    if (!parsePose(sensor.origin_, o))
+      return false;
+  }
+
+  // parse sensor
+  sensor.sensor_ = parseSensorBase(config, parsers);
+  return static_cast<bool>(sensor.sensor_);
+}
+
+URDFDOM_DLLAPI
+SensorMap parseSensors(TiXmlDocument &urdf_xml,  const SensorParserMap &parsers)
+{
+  TiXmlElement *robot_xml = urdf_xml.FirstChildElement("robot");
+  if (!robot_xml) {
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the URDF");
+  }
+
+  SensorMap results;
+  // Get all sensor elements
+  for (TiXmlElement* sensor_xml = robot_xml->FirstChildElement("sensor");
+       sensor_xml; sensor_xml = sensor_xml->NextSiblingElement("sensor"))
+  {
+    SensorSharedPtr sensor;
+    sensor.reset(new Sensor);
+
+    if (parseSensor(*sensor, sensor_xml, parsers))
+    {
+      if (results.find(sensor->name_) != results.end())
+      {
+        CONSOLE_BRIDGE_logWarn("Sensor '%s' is not unique. Ignoring consecutive ones.", sensor->name_.c_str());
+      }
+      else
+      {
+        results.insert(make_pair(sensor->name_, sensor));
+        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new sensor '%s'", sensor->name_.c_str());
+      }
+    }
+    else
+    {
+      CONSOLE_BRIDGE_logError("failed to parse sensor element");
+    }
+  }
+  return results;
+}
+
+}

--- a/urdf_parser/src/sensor_parser.cpp
+++ b/urdf_parser/src/sensor_parser.cpp
@@ -61,7 +61,12 @@ SensorBaseSharedPtr parseSensorBase(TiXmlElement *sensor_xml, const SensorParser
     SensorParserMap::const_iterator parser = parsers.find(sensor_type);
     if (parser != parsers.end() && parser->second)
     {
-      return parser->second->parse(*sensor_base_xml);
+      // Link sensor's deleter to the parser.
+      // If the parser was loaded via a pluginlib, this is required to link
+      // the lifetime of the parser/library to the created sensor instances.
+      return SensorBaseSharedPtr(parser->second->parse(*sensor_base_xml),
+                                 [linked_parser = parser->second](auto *p)
+                                 { delete p; });
     }
     else
     {

--- a/urdf_parser/src/sensor_parser.cpp
+++ b/urdf_parser/src/sensor_parser.cpp
@@ -36,11 +36,10 @@
 
 
 #include "urdf_parser/sensor_parser.h"
+
 #include "urdf_parser/pose.h"
 #include <urdf_sensor/camera.h>
 #include <urdf_sensor/ray.h>
-
-#include <boost/lexical_cast.hpp>
 #include <console_bridge/console.h>
 
 namespace urdf {

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -44,12 +44,11 @@
 #include <algorithm>
 #include <tinyxml.h>
 #include <console_bridge/console.h>
+#include "urdf_parser/pose.h"
 
 #include <urdf_parser/urdf_parser.h>
 
 namespace urdf{
-
-bool parsePose(Pose &pose, TiXmlElement* xml);
 
 bool parseCamera(Camera &camera, TiXmlElement* config)
 {

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -334,11 +334,12 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   }
   sensor.name = std::string(name_char);
 
-  // parse parent_link_name
-  const char *parent_link_name_char = config->Attribute("parent_link_name");
+  // parse parent link name
+  TiXmlElement *parent_xml = config->FirstChildElement("parent");
+  const char *parent_link_name_char = parent_xml ? parent_xml->Attribute("link") : NULL;
   if (!parent_link_name_char)
   {
-    CONSOLE_BRIDGE_logError("No parent_link_name given for the sensor.");
+    CONSOLE_BRIDGE_logError("No parent link name given for the sensor.");
     return false;
   }
   sensor.parent_link_name = std::string(parent_link_name_char);

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -288,36 +288,39 @@ bool parseRay(Ray &ray, TiXmlElement* config)
       }
     }
   }
-  return false;
+  return true;
 }
 
-VisualSensorSharedPtr parseVisualSensor(TiXmlElement *g)
+SensorBaseSharedPtr parseSensorBase(TiXmlElement *g)
 {
-  VisualSensorSharedPtr visual_sensor;
+  SensorBaseSharedPtr sensor_;
 
   // get sensor type
   TiXmlElement *sensor_xml;
   if (g->FirstChildElement("camera"))
   {
     Camera *camera = new Camera();
-    visual_sensor.reset(camera);
+    sensor_.reset(camera);
+    sensor_->sensor_type = SensorBase::VISUAL;
     sensor_xml = g->FirstChildElement("camera");
     if (!parseCamera(*camera, sensor_xml))
-      visual_sensor.reset();
+      sensor_.reset();
   }
   else if (g->FirstChildElement("ray"))
   {
     Ray *ray = new Ray();
-    visual_sensor.reset(ray);
+    sensor_.reset(ray);
+    sensor_->sensor_type = SensorBase::VISUAL;
     sensor_xml = g->FirstChildElement("ray");
     if (!parseRay(*ray, sensor_xml))
-      visual_sensor.reset();
+      sensor_.reset();
   }
   else
   {
     CONSOLE_BRIDGE_logError("No know sensor types [camera|ray] defined in <sensor> block");
   }
-  return visual_sensor;
+
+  return sensor_;
 }
 
 
@@ -352,7 +355,7 @@ bool parseSensor(Sensor &sensor, TiXmlElement* config)
   }
 
   // parse sensor
-  sensor.sensor = parseVisualSensor(config);
+  sensor.sensor = parseSensorBase(config);
   return true;
 }
 

--- a/urdf_parser/src/visual_sensor_parsers.cpp
+++ b/urdf_parser/src/visual_sensor_parsers.cpp
@@ -44,52 +44,52 @@
 
 namespace urdf {
 
-SensorBaseSharedPtr CameraParser::parse(TiXmlElement &config)
+SensorBase* CameraParser::parse(TiXmlElement &config)
 {
   TiXmlElement *image = config.FirstChildElement("image");
   if (image)
   {
     try {
-      CameraSharedPtr camera(new Camera());
+      std::unique_ptr<Camera> camera(new Camera());
       camera->width = parseAttribute<unsigned int>(*image, "width");
       camera->height = parseAttribute<unsigned int>(*image, "height");
       camera->format = parseAttribute<std::string>(*image, "format");
       camera->hfov = parseAttribute<double>(*image, "hfov");
       camera->near = parseAttribute<double>(*image, "near");
       camera->far = parseAttribute<double>(*image, "far");
-      return camera;
+      return camera.release();
     }
     catch (const std::exception &e)
     {
       CONSOLE_BRIDGE_logError("Camera sensor %s", e.what());
-      return CameraSharedPtr();
+      return nullptr;
     }
   }
   else
   {
     CONSOLE_BRIDGE_logError("Camera sensor has no <image> element");
-    return CameraSharedPtr();
+    return nullptr;
   }
 }
 
 
-SensorBaseSharedPtr RayParser::parse(TiXmlElement &config)
+SensorBase* RayParser::parse(TiXmlElement &config)
 {
   TiXmlElement *horizontal = config.FirstChildElement("horizontal");
   if (horizontal)
   {
     try {
-      RaySharedPtr ray (new Ray());
+      std::unique_ptr<Ray> ray(new Ray());
       ray->horizontal_samples = parseAttribute<unsigned int>(*horizontal, "samples");
       ray->horizontal_resolution = parseAttribute<double>(*horizontal, "resolution");
       ray->horizontal_min_angle = parseAttribute<double>(*horizontal, "min_angle");
       ray->horizontal_max_angle = parseAttribute<double>(*horizontal, "max_angle");
-      return ray;
+      return ray.release();
     }
     catch (const std::exception &e)
     {
       CONSOLE_BRIDGE_logError("Ray horizontal: %s", e.what());
-      return RaySharedPtr();
+      return nullptr;
     }
   }
 
@@ -97,20 +97,20 @@ SensorBaseSharedPtr RayParser::parse(TiXmlElement &config)
   if (vertical)
   {
     try {
-      RaySharedPtr ray (new Ray());
+      std::unique_ptr<Ray> ray(new Ray());
       ray->vertical_samples = parseAttribute<unsigned int>(*vertical, "samples");
       ray->vertical_resolution = parseAttribute<double>(*vertical, "resolution");
       ray->vertical_min_angle = parseAttribute<double>(*vertical, "min_angle");
       ray->vertical_max_angle = parseAttribute<double>(*vertical, "max_angle");
-      return ray;
+      return ray.release();
     }
     catch (const std::exception &e)
     {
       CONSOLE_BRIDGE_logError("Ray horizontal: %s", e.what());
-      return RaySharedPtr();
+      return nullptr;
     }
   }
-  return RaySharedPtr();
+  return nullptr;
 }
 
 }

--- a/urdf_parser/src/visual_sensor_parsers.cpp
+++ b/urdf_parser/src/visual_sensor_parsers.cpp
@@ -35,259 +35,82 @@
 /* Author: John Hsu */
 
 #include "urdf_parser/visual_sensor_parsers.h"
+#include "urdf_parser/utils.h"
+#include "urdf_parser/pose.h"
 #include <urdf_sensor/camera.h>
 #include <urdf_sensor/ray.h>
 
-#include <fstream>
-#include <locale>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <algorithm>
-#include <tinyxml.h>
 #include <console_bridge/console.h>
-#include "urdf_parser/pose.h"
 
 namespace urdf {
 
 SensorBaseSharedPtr CameraParser::parse(TiXmlElement &config)
 {
-  CameraSharedPtr camera(new Camera());
-
   TiXmlElement *image = config.FirstChildElement("image");
   if (image)
   {
-    const char* width_char = image->Attribute("width");
-    if (width_char)
-    {
-      try
-      {
-        camera->width = std::stoul(width_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image width [%s] is not a valid int: %s", width_char, e.what());
-        return CameraSharedPtr();
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image width [%s] is out of range: %s", width_char, e.what());
-        return CameraSharedPtr();
-      }
+    try {
+      CameraSharedPtr camera(new Camera());
+      camera->width = parseAttribute<unsigned int>(*image, "width");
+      camera->height = parseAttribute<unsigned int>(*image, "height");
+      camera->format = parseAttribute<std::string>(*image, "format");
+      camera->hfov = parseAttribute<double>(*image, "hfov");
+      camera->near = parseAttribute<double>(*image, "near");
+      camera->far = parseAttribute<double>(*image, "far");
+      return camera;
     }
-    else
+    catch (const std::exception &e)
     {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image width attribute");
+      CONSOLE_BRIDGE_logError("Camera sensor %s", e.what());
       return CameraSharedPtr();
     }
-
-    const char* height_char = image->Attribute("height");
-    if (height_char)
-    {
-      try
-      {
-        camera->height = std::stoul(height_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image height [%s] is not a valid int: %s", height_char, e.what());
-        return CameraSharedPtr();
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image height [%s] is out of range: %s", height_char, e.what());
-        return CameraSharedPtr();
-      }
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image height attribute");
-      return CameraSharedPtr();
-    }
-
-    const char* format_char = image->Attribute("format");
-    if (format_char)
-      camera->format = std::string(format_char);
-    else
-    {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image format attribute");
-      return CameraSharedPtr();
-    }
-
-    const char* hfov_char = image->Attribute("hfov");
-    if (hfov_char)
-    {
-      try {
-        camera->hfov = strToDouble(hfov_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Camera image hfov [%s] is not a valid float", hfov_char);
-        return CameraSharedPtr();
-      }
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image hfov attribute");
-      return CameraSharedPtr();
-    }
-
-    const char* near_char = image->Attribute("near");
-    if (near_char)
-    {
-      try {
-        camera->near = strToDouble(near_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Camera image near [%s] is not a valid float", near_char);
-        return CameraSharedPtr();
-      }
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image near attribute");
-      return CameraSharedPtr();
-    }
-
-    const char* far_char = image->Attribute("far");
-    if (far_char)
-    {
-      try {
-        camera->far = strToDouble(far_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Camera image far [%s] is not a valid float", far_char);
-        return CameraSharedPtr();
-      }
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logError("Camera sensor needs an image far attribute");
-      return CameraSharedPtr();
-    }
-
   }
   else
   {
     CONSOLE_BRIDGE_logError("Camera sensor has no <image> element");
     return CameraSharedPtr();
   }
-  return camera;
 }
 
 
 SensorBaseSharedPtr RayParser::parse(TiXmlElement &config)
 {
-  RaySharedPtr ray (new Ray());
-
   TiXmlElement *horizontal = config.FirstChildElement("horizontal");
   if (horizontal)
   {
-    const char* samples_char = horizontal->Attribute("samples");
-    if (samples_char)
-    {
-      try
-      {
-        ray->horizontal_samples = std::stoul(samples_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal samples [%s] is not a valid float: %s", samples_char, e.what());
-        return RaySharedPtr();
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal samples [%s] is out of range: %s", samples_char, e.what());
-        return RaySharedPtr();
-      }
+    try {
+      RaySharedPtr ray (new Ray());
+      ray->horizontal_samples = parseAttribute<unsigned int>(*horizontal, "samples");
+      ray->horizontal_resolution = parseAttribute<double>(*horizontal, "resolution");
+      ray->horizontal_min_angle = parseAttribute<double>(*horizontal, "min_angle");
+      ray->horizontal_max_angle = parseAttribute<double>(*horizontal, "max_angle");
+      return ray;
     }
-
-    const char* resolution_char = horizontal->Attribute("resolution");
-    if (resolution_char)
+    catch (const std::exception &e)
     {
-      try {
-        ray->horizontal_resolution = strToDouble(resolution_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray horizontal resolution [%s] is not a valid float", resolution_char);
-        return RaySharedPtr();
-      }
-    }
-
-    const char* min_angle_char = horizontal->Attribute("min_angle");
-    if (min_angle_char)
-    {
-      try {
-        ray->horizontal_min_angle = strToDouble(min_angle_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray horizontal min_angle [%s] is not a valid float", min_angle_char);
-        return RaySharedPtr();
-      }
-    }
-
-    const char* max_angle_char = horizontal->Attribute("max_angle");
-    if (max_angle_char)
-    {
-      try {
-        ray->horizontal_max_angle = strToDouble(max_angle_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray horizontal max_angle [%s] is not a valid float", max_angle_char);
-        return RaySharedPtr();
-      }
+      CONSOLE_BRIDGE_logError("Ray horizontal: %s", e.what());
+      return RaySharedPtr();
     }
   }
 
   TiXmlElement *vertical = config.FirstChildElement("vertical");
   if (vertical)
   {
-    const char* samples_char = vertical->Attribute("samples");
-    if (samples_char)
-    {
-      try
-      {
-        ray->vertical_samples = std::stoul(samples_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical samples [%s] is not a valid float: %s", samples_char, e.what());
-        return RaySharedPtr();
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical samples [%s] is out of range: %s", samples_char, e.what());
-        return RaySharedPtr();
-      }
+    try {
+      RaySharedPtr ray (new Ray());
+      ray->vertical_samples = parseAttribute<unsigned int>(*vertical, "samples");
+      ray->vertical_resolution = parseAttribute<double>(*vertical, "resolution");
+      ray->vertical_min_angle = parseAttribute<double>(*vertical, "min_angle");
+      ray->vertical_max_angle = parseAttribute<double>(*vertical, "max_angle");
+      return ray;
     }
-
-    const char* resolution_char = vertical->Attribute("resolution");
-    if (resolution_char)
+    catch (const std::exception &e)
     {
-      try {
-        ray->vertical_resolution = strToDouble(resolution_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray vertical resolution [%s] is not a valid float", resolution_char);
-        return RaySharedPtr();
-      }
-    }
-
-    const char* min_angle_char = vertical->Attribute("min_angle");
-    if (min_angle_char)
-    {
-      try {
-        ray->vertical_min_angle = strToDouble(min_angle_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray vertical min_angle [%s] is not a valid float", min_angle_char);
-        return RaySharedPtr();
-      }
-    }
-
-    const char* max_angle_char = vertical->Attribute("max_angle");
-    if (max_angle_char)
-    {
-      try {
-        ray->vertical_max_angle = strToDouble(max_angle_char);
-      } catch(std::runtime_error &) {
-        CONSOLE_BRIDGE_logError("Ray vertical max_angle [%s] is not a valid float", max_angle_char);
-        return RaySharedPtr();
-      }
+      CONSOLE_BRIDGE_logError("Ray horizontal: %s", e.what());
+      return RaySharedPtr();
     }
   }
-  return ray;
+  return RaySharedPtr();
 }
 
 }

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -30,18 +30,21 @@ foreach(GTEST_SOURCE_file ${tests})
     gtest_main
     gtest
     urdfdom_model
+    urdfdom_sensor
   )
   if (UNIX)
     target_link_libraries(${BINARY_NAME} pthread)
   endif()
 
   add_test(NAME    ${BINARY_NAME}
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
   set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240 ENVIRONMENT LC_ALL=C)
 
   add_test(NAME    ${BINARY_NAME}_locale
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}_locale.xml)
 

--- a/urdf_parser/test/basic.urdf
+++ b/urdf_parser/test/basic.urdf
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="robot" version="1.0" xmlns="http://www.ros.org">
+  <link name="link1"/>
+  <link name="link2"/>
+  <joint name="joint1" type="floating">
+    <parent link="link1" />
+    <child link="link2" />
+  </joint>
+  <sensor name="camera1" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <camera>
+      <image width="640" height="480" hfov="1.5708" format="RGB8" near="0.01" far="50.0"/>
+    </camera>
+  </sensor>
+  <sensor name="ray1" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <ray>
+      <horizontal samples="100" resolution="1" min_angle="-1.5708" max_angle="1.5708"/>
+      <vertical samples="1" resolution="1" min_angle="0" max_angle="0"/>
+    </ray>
+  </sensor>
+
+  <sensor name="missing sensor" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor>
+  <sensor name="unknown sensor" update_rate="20">
+    <parent link="link1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <unknown/>
+  </sensor>
+</robot>


### PR DESCRIPTION
This PR is an attempt to rework sensor parsing towards more modularity as requested e.g. in #28. My guidelines were the following (according to the previous discussions in #82 and #28):
- Don't touch the `udf::ModelInterface`. Particularly, I didn't put the list of parsed sensors into that data structure as suggested in #28. The rationale is the following: The `ModelInterface` defines the kinematic structure of the robot, which is kind of universal and doesn't require specific data types (other than the existing ones) to describe it. On the other hand, there is a whole universe of sensors out there, each requiring its own data type and parser. So sensors are obviously highly domain-specific and we will need a plugin concept to handle them in a generic fashion.
- Accordingly, I was thinking about a separate sensor parser, that returns a list of successfully parsed `<sensor>` tags in the URDF. This generic parser handles common fields as defined in the original `Sensor` class. In order to handle the multitude of potential sensor descriptions, I propose to pass application-specific sensor parsers to that method via a map from sensor type to the associated parser instance.
- The list of available sensor parsers should be loaded via the `pluginlib` mechanism of ROS. However, as `liburdfdom` should be ROS-agnostic, corresponding functions are provided in the `urdf` package only (https://github.com/ros/urdf/pull/5).
- The association of XML sensor elements to appropriate parsers is done via the sensor type. I have chosen to identify the sensor type by the first non-standard tag below `<sensor>`. This maintains backward compatibility to potentially existing ray and camera sensor descriptions:
  ```xml
  <sensor name="camera1" update_rate="20">
    <parent link="link1"/>
    <origin xyz="0 0 0" rpy="0 0 0"/>
    <camera>
      <image width="640" height="480" hfov="1.5708" format="RGB8" near="0.01" far="50.0"/>
    </camera>
  </sensor>
  ```
  Alternatively, the type could be specified via an attribute of the `<sensor>` tag.
- As there might evolve different parsers and descriptions with `identical` sensor type names in the future, we might need a mechanism to explicitly specify a parser from a specific package.

Accordingly, these commits:
- merge #28 - renaming `VisualSensor` to `SensorBase` (previously only two sensor types could be handled, camera and ray).
- refactor the existing parsing functions `parseCamera()` and `parseRay()` functions into appropriate parser classes, derived from a new interface class, `urdf::SensorParser`.
- defining a utility function parseAttribute() I could simplify the parsing functions for camera and ray dramatically.
- A usage example can be found in the unittest.
