### PR TITLE
Change link description to use choice instead of all.

### DIFF
--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -148,14 +148,14 @@
 
   <!-- link node type -->
   <xs:complexType name="link">
-    <xs:all>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="inertial"
-		  type="inertial" minOccurs="0" maxOccurs="1" />
+                  type="inertial" minOccurs="0" maxOccurs="1" />
       <xs:element name="visual"
-		  type="visual" minOccurs="0" maxOccurs="unbounded" />
+                  type="visual" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="collision"
-		  type="collision" minOccurs="0" maxOccurs="unbounded" />
-    </xs:all>
+                  type="collision" minOccurs="0" maxOccurs="unbounded" />
+    </xs:choice>
     <xs:attribute name="name" type="xs:string" use="required" />
 
     <!-- FIXME: undocumented but used by PR2 -->


### PR DESCRIPTION
See ros/urdfdom#95

Unbounded elements in all are fine in XSD 1.1 but not valid in XSD 1.0.
There aren't a ton of technologies out in the wild that leverage XSD 1.1
(e.g. code generators). This definition should be acceptable for
validation of XML documents but I'm not convinced it's a nice way to do
things re: code generation, as the code generated by XJC for example
contains a single List field containing the inertial and the
collisions/visuals.