### PR TITLE
Cleanup error checking in urdfdom

### DIFF
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -485,16 +485,14 @@ bool parseLink(Link &link, TiXmlElement* config)
 
     VisualSharedPtr vis;
     vis.reset(new Visual());
-    if (parseVisual(*vis, vis_xml))
-    {
-      link.visual_array.push_back(vis);
-    }
-    else
+    if (!parseVisual(*vis, vis_xml))
     {
       vis.reset();
       CONSOLE_BRIDGE_logError("Could not parse visual element for Link [%s]", link.name.c_str());
       return false;
     }
+
+    link.visual_array.push_back(vis);
   }
 
   // Visual (optional)
@@ -507,16 +505,13 @@ bool parseLink(Link &link, TiXmlElement* config)
   {
     CollisionSharedPtr col;
     col.reset(new Collision());
-    if (parseCollision(*col, col_xml))
-    {      
-      link.collision_array.push_back(col);
-    }
-    else
+    if (!parseCollision(*col, col_xml))
     {
       col.reset();
       CONSOLE_BRIDGE_logError("Could not parse collision element for Link [%s]",  link.name.c_str());
       return false;
     }
+    link.collision_array.push_back(col);
   }
   
   // Collision (optional)  

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -98,27 +98,30 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     MaterialSharedPtr material;
     material.reset(new Material);
 
+    bool success;
     try {
-      parseMaterial(*material, material_xml, false); // material needs to be fully defined here
-      if (model->getMaterial(material->name))
-      {
-        CONSOLE_BRIDGE_logError("material '%s' is not unique.", material->name.c_str());
-        material.reset();
-        model.reset();
-        return model;
-      }
-      else
-      {
-        model->materials_.insert(make_pair(material->name,material));
-        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new material '%s'", material->name.c_str());
-      }
+      success = parseMaterial(*material, material_xml, false); // material needs to be fully defined here
+    } catch(ParseError &) {
+      success = false;
     }
-    catch (ParseError &/*e*/) {
+
+    if (!success) {
       CONSOLE_BRIDGE_logError("material xml is not initialized correctly");
       material.reset();
       model.reset();
       return model;
     }
+
+    if (model->getMaterial(material->name))
+    {
+      CONSOLE_BRIDGE_logError("material '%s' is not unique.", material->name.c_str());
+      material.reset();
+      model.reset();
+      return model;
+    }
+
+    model->materials_.insert(make_pair(material->name,material));
+    CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new material '%s'", material->name.c_str());
   }
 
   // Get all Link elements
@@ -127,54 +130,56 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     LinkSharedPtr link;
     link.reset(new Link);
 
+    bool success;
     try {
-      parseLink(*link, link_xml);
-      if (model->getLink(link->name))
-      {
-        CONSOLE_BRIDGE_logError("link '%s' is not unique.", link->name.c_str());
-        model.reset();
-        return model;
-      }
-      else
-      {
-        // set link visual material
-        CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material", link->name.c_str());
-        if (link->visual)
-        {
-          if (!link->visual->material_name.empty())
-          {
-            if (model->getMaterial(link->visual->material_name))
-            {
-              CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material to '%s'", link->name.c_str(),link->visual->material_name.c_str());
-              link->visual->material = model->getMaterial( link->visual->material_name.c_str() );
-            }
-            else
-            {
-              if (link->visual->material)
-              {
-                CONSOLE_BRIDGE_logDebug("urdfdom: link '%s' material '%s' defined in Visual.", link->name.c_str(),link->visual->material_name.c_str());
-                model->materials_.insert(make_pair(link->visual->material->name,link->visual->material));
-              }
-              else
-              {
-                CONSOLE_BRIDGE_logError("link '%s' material '%s' undefined.", link->name.c_str(),link->visual->material_name.c_str());
-                model.reset();
-                return model;
-              }
-            }
-          }
-        }
-
-        model->links_.insert(make_pair(link->name,link));
-        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new link '%s'", link->name.c_str());
-      }
+      success = parseLink(*link, link_xml);
+    } catch (ParseError &) {
+      success = false;
     }
-    catch (ParseError &/*e*/) {
+
+    if (!success) {
       CONSOLE_BRIDGE_logError("link xml is not initialized correctly");
       model.reset();
       return model;
     }
+
+    if (model->getLink(link->name))
+    {
+      CONSOLE_BRIDGE_logError("link '%s' is not unique.", link->name.c_str());
+      model.reset();
+      return model;
+    }
+
+    // set link visual material
+    CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material", link->name.c_str());
+    if (link->visual)
+    {
+      if (!link->visual->material_name.empty())
+      {
+        if (model->getMaterial(link->visual->material_name))
+        {
+          CONSOLE_BRIDGE_logDebug("urdfdom: setting link '%s' material to '%s'", link->name.c_str(),link->visual->material_name.c_str());
+          link->visual->material = model->getMaterial( link->visual->material_name.c_str() );
+        }
+        else
+        {
+          if (!link->visual->material)
+          {
+            CONSOLE_BRIDGE_logError("link '%s' material '%s' undefined.", link->name.c_str(),link->visual->material_name.c_str());
+            model.reset();
+            return model;
+          }
+
+          CONSOLE_BRIDGE_logDebug("urdfdom: link '%s' material '%s' defined in Visual.", link->name.c_str(),link->visual->material_name.c_str());
+          model->materials_.insert(make_pair(link->visual->material->name,link->visual->material));
+        }
+      }
+    }
+
+    model->links_.insert(make_pair(link->name, link));
+    CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new link '%s'", link->name.c_str());
   }
+
   if (model->links_.empty()){
     CONSOLE_BRIDGE_logError("No link elements found in urdf file");
     model.reset();
@@ -187,26 +192,28 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     JointSharedPtr joint;
     joint.reset(new Joint);
 
-    if (parseJoint(*joint, joint_xml))
-    {
-      if (model->getJoint(joint->name))
-      {
-        CONSOLE_BRIDGE_logError("joint '%s' is not unique.", joint->name.c_str());
-        model.reset();
-        return model;
-      }
-      else
-      {
-        model->joints_.insert(make_pair(joint->name,joint));
-        CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new joint '%s'", joint->name.c_str());
-      }
+    bool success;
+    try {
+      success = parseJoint(*joint, joint_xml);
+    } catch(ParseError &) {
+      success = false;
     }
-    else
-    {
+
+    if (!success) {
       CONSOLE_BRIDGE_logError("joint xml is not initialized correctly");
       model.reset();
       return model;
     }
+
+    if (model->getJoint(joint->name))
+    {
+      CONSOLE_BRIDGE_logError("joint '%s' is not unique.", joint->name.c_str());
+      model.reset();
+      return model;
+    }
+
+    model->joints_.insert(make_pair(joint->name,joint));
+    CONSOLE_BRIDGE_logDebug("urdfdom: successfully added a new joint '%s'", joint->name.c_str());
   }
 
 


### PR DESCRIPTION
This does two things:

1.  Check the return value from parseMaterial, parseLink, and parseJoint.  While these can throw a ParseError exception, most often they return false when they fail to parse.
1.  Revamp the error checking around those calls so that the  code is indented a lot less.  It is much easier to read this way.

The first point, in particular, has the chance to have a bit of semantic change in that XML that was "accepted" before may be dropped now.  However, I think it is worthwhile doing the correct thing here, though we may want to think about only putting this in Lunar and newer.