### PR TITLE
Switch all stod callers in urdfdom to use a helper

### DIFF
--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -34,6 +34,7 @@
 
 /* Author: John Hsu */
 
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -58,18 +59,10 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jd.damping = std::stod(damping_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("damping value (%s) is not a float: %s",damping_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("damping value (%s) out of range: %s",damping_str, e.what());
+    try {
+      jd.damping = strToDouble(damping_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("damping value (%s) is not a valid float", damping_str);
       return false;
     }
   }
@@ -82,18 +75,10 @@ bool parseJointDynamics(JointDynamics &jd, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jd.friction = std::stod(friction_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("friction value (%s) is not a float: %s",friction_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("friction value (%s) out of range: %s",friction_str, e.what());
+    try {
+      jd.friction = strToDouble(friction_str);
+    } catch (std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("friction value (%s) is not a valid float", friction_str);
       return false;
     }
   }
@@ -121,18 +106,10 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jl.lower = std::stod(lower_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("lower value (%s) is not a float: %s", lower_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("lower value (%s) out of range: %s",lower_str, e.what());
+    try {
+      jl.lower = strToDouble(lower_str);
+    } catch (std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("lower value (%s) is not a valid float", lower_str);
       return false;
     }
   }
@@ -145,18 +122,10 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jl.upper = std::stod(upper_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("upper value (%s) is not a float: %s",upper_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("upper value (%s) out of range: %s",upper_str, e.what());
+    try {
+      jl.upper = strToDouble(upper_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("upper value (%s) is not a valid float", upper_str);
       return false;
     }
   }
@@ -169,18 +138,10 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jl.effort = std::stod(effort_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("effort value (%s) is not a float: %s",effort_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("effort value (%s) out of range: %s",effort_str, e.what());
+    try {
+      jl.effort = strToDouble(effort_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("effort value (%s) is not a valid float", effort_str);
       return false;
     }
   }
@@ -193,18 +154,10 @@ bool parseJointLimits(JointLimits &jl, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jl.velocity = std::stod(velocity_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("velocity value (%s) is not a float: %s",velocity_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("velocity value (%s) out of range: %s",velocity_str, e.what());
+    try {
+      jl.velocity = strToDouble(velocity_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("velocity value (%s) is not a valid float", velocity_str);
       return false;
     }
   }
@@ -225,18 +178,10 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      js.soft_lower_limit = std::stod(soft_lower_limit_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("soft_lower_limit value (%s) is not a float: %s",soft_lower_limit_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("soft_lower_limit value (%s) out of range: %s",soft_lower_limit_str, e.what());
+    try {
+      js.soft_lower_limit = strToDouble(soft_lower_limit_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("soft_lower_limit value (%s) is not a valid float", soft_lower_limit_str);
       return false;
     }
   }
@@ -250,18 +195,10 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      js.soft_upper_limit = std::stod(soft_upper_limit_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("soft_upper_limit value (%s) is not a float: %s",soft_upper_limit_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("soft_upper_limit value (%s) out of range: %s",soft_upper_limit_str, e.what());
+    try {
+      js.soft_upper_limit = strToDouble(soft_upper_limit_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("soft_upper_limit value (%s) is not a valid float", soft_upper_limit_str);
       return false;
     }
   }
@@ -275,18 +212,10 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      js.k_position = std::stod(k_position_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("k_position value (%s) is not a float: %s",k_position_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("k_position value (%s) out of range: %s",k_position_str, e.what());
+    try {
+      js.k_position = strToDouble(k_position_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("k_position value (%s) is not a valid float", k_position_str);
       return false;
     }
   }
@@ -299,18 +228,10 @@ bool parseJointSafety(JointSafety &js, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      js.k_velocity = std::stod(k_velocity_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("k_velocity value (%s) is not a float: %s",k_velocity_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("k_velocity value (%s) out of range: %s",k_velocity_str, e.what());
+    try {
+      js.k_velocity = strToDouble(k_velocity_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("k_velocity value (%s) is not a valid float", k_velocity_str);
       return false;
     }
   }
@@ -331,18 +252,10 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jc.rising.reset(new double(std::stod(rising_position_str)));
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("risingvalue (%s) is not a float: %s",rising_position_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("risingvalue (%s) out of range: %s",rising_position_str, e.what());
+    try {
+      jc.rising.reset(new double(strToDouble(rising_position_str)));
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("rising value (%s) is not a valid float", rising_position_str);
       return false;
     }
   }
@@ -356,18 +269,10 @@ bool parseJointCalibration(JointCalibration &jc, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jc.falling.reset(new double(std::stod(falling_position_str)));
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("fallingvalue (%s) is not a float: %s",falling_position_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("fallingvalue (%s) out of range: %s",falling_position_str, e.what());
+    try {
+      jc.falling.reset(new double(strToDouble(falling_position_str)));
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("falling value (%s) is not a valid float", falling_position_str);
       return false;
     }
   }
@@ -400,18 +305,10 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jm.multiplier = std::stod(multiplier_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("multiplier value (%s) is not a float: %s",multiplier_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("multiplier value (%s) out of range: %s",multiplier_str, e.what());
+    try {
+      jm.multiplier = strToDouble(multiplier_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("multiplier value (%s) is not a valid float", multiplier_str);
       return false;
     }
   }
@@ -426,18 +323,10 @@ bool parseJointMimic(JointMimic &jm, TiXmlElement* config)
   }
   else
   {
-    try
-    {
-      jm.offset = std::stod(offset_str);
-    }
-    catch (std::invalid_argument &e)
-    {
-      CONSOLE_BRIDGE_logError("offset value (%s) is not a float: %s",offset_str, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e)
-    {
-      CONSOLE_BRIDGE_logError("offset value (%s) out of range: %s",offset_str, e.what());
+    try {
+      jm.offset = strToDouble(offset_str);
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("offset value (%s) is not a valid float", offset_str);
       return false;
     }
   }

--- a/urdf_parser/src/urdf_model_state.cpp
+++ b/urdf_parser/src/urdf_model_state.cpp
@@ -38,6 +38,7 @@
 #include <urdf_model_state/model_state.h>
 #include <urdf_model/utils.h>
 #include <fstream>
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -63,15 +64,9 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
   if (time_stamp_char)
   {
     try {
-      double sec = std::stod(time_stamp_char);
-      ms.time_stamp.set(sec);
-    }
-    catch (std::invalid_argument &e) {
-      CONSOLE_BRIDGE_logError("Parsing time stamp [%s] failed: %s", time_stamp_char, e.what());
-      return false;
-    }
-    catch (std::out_of_range &e) {
-      CONSOLE_BRIDGE_logError("Parsing time stamp [%s] failed, out of range: %s", time_stamp_char, e.what());
+      ms.time_stamp.set(strToDouble(time_stamp_char));
+    } catch(std::runtime_error &) {
+      CONSOLE_BRIDGE_logError("Parsing time stamp [%s] failed", time_stamp_char);
       return false;
     }
   }
@@ -101,13 +96,9 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
       for (unsigned int i = 0; i < pieces.size(); ++i){
         if (pieces[i] != ""){
           try {
-            joint_state->position.push_back(std::stod(pieces[i].c_str()));
-          }
-          catch (std::invalid_argument &/*e*/) {
+            joint_state->position.push_back(strToDouble(pieces[i].c_str()));
+          } catch(std::runtime_error &) {
             throw ParseError("position element ("+ pieces[i] +") is not a valid float");
-          }
-          catch (std::out_of_range &/*e*/) {
-            throw ParseError("position element ("+ pieces[i] +") is out of range");
           }
         }
       }
@@ -123,13 +114,9 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
       for (unsigned int i = 0; i < pieces.size(); ++i){
         if (pieces[i] != ""){
           try {
-            joint_state->velocity.push_back(std::stod(pieces[i].c_str()));
-          }
-          catch (std::invalid_argument &/*e*/) {
+            joint_state->velocity.push_back(strToDouble(pieces[i].c_str()));
+          } catch(std::runtime_error &) {
             throw ParseError("velocity element ("+ pieces[i] +") is not a valid float");
-          }
-          catch (std::out_of_range &/*e*/) {
-            throw ParseError("velocity element ("+ pieces[i] +") is out of range");
           }
         }
       }
@@ -145,13 +132,9 @@ bool parseModelState(ModelState &ms, TiXmlElement* config)
       for (unsigned int i = 0; i < pieces.size(); ++i){
         if (pieces[i] != ""){
           try {
-            joint_state->effort.push_back(std::stod(pieces[i].c_str()));
-          }
-          catch (std::invalid_argument &/*e*/) {
+            joint_state->effort.push_back(strToDouble(pieces[i].c_str()));
+          } catch(std::runtime_error &) {
             throw ParseError("effort element ("+ pieces[i] +") is not a valid float");
-          }
-          catch (std::out_of_range &/*e*/) {
-            throw ParseError("effort element ("+ pieces[i] +") is out of range");
           }
         }
       }

--- a/urdf_parser/src/urdf_sensor.cpp
+++ b/urdf_parser/src/urdf_sensor.cpp
@@ -37,6 +37,7 @@
 
 #include <urdf_sensor/sensor.h>
 #include <fstream>
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -116,18 +117,10 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
     const char* hfov_char = image->Attribute("hfov");
     if (hfov_char)
     {
-      try
-      {
-        camera.hfov = std::stod(hfov_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image hfov [%s] is not a valid float: %s", hfov_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image hfov [%s] is out of range: %s", hfov_char, e.what());
+      try {
+        camera.hfov = strToDouble(hfov_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Camera image hfov [%s] is not a valid float", hfov_char);
         return false;
       }
     }
@@ -140,18 +133,10 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
     const char* near_char = image->Attribute("near");
     if (near_char)
     {
-      try
-      {
-        camera.near = std::stod(near_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image near [%s] is not a valid float: %s", near_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image near [%s] is out of range: %s", near_char, e.what());
+      try {
+        camera.near = strToDouble(near_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Camera image near [%s] is not a valid float", near_char);
         return false;
       }
     }
@@ -164,18 +149,10 @@ bool parseCamera(Camera &camera, TiXmlElement* config)
     const char* far_char = image->Attribute("far");
     if (far_char)
     {
-      try
-      {
-        camera.far = std::stod(far_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image far [%s] is not a valid float: %s", far_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Camera image far [%s] is out of range: %s", far_char, e.what());
+      try {
+        camera.far = strToDouble(far_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Camera image far [%s] is not a valid float", far_char);
         return false;
       }
     }
@@ -224,37 +201,21 @@ bool parseRay(Ray &ray, TiXmlElement* config)
     const char* resolution_char = horizontal->Attribute("resolution");
     if (resolution_char)
     {
-      try
-      {
-        ray.horizontal_resolution = std::stod(resolution_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal resolution [%s] is not a valid float: %s", resolution_char, e.what());
+      try {
+        ray.horizontal_resolution = strToDouble(resolution_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray horizontal resolution [%s] is not a valid float", resolution_char);
         return false;
       }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal resolution [%s] is out of range: %s", resolution_char, e.what());
-        return false;
-      }
-    }   
-    
+    }
+
     const char* min_angle_char = horizontal->Attribute("min_angle");
     if (min_angle_char)
     {
-      try
-      {
-        ray.horizontal_min_angle = std::stod(min_angle_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal min_angle [%s] is out of range: %s", min_angle_char, e.what());
+      try {
+        ray.horizontal_min_angle = strToDouble(min_angle_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray horizontal min_angle [%s] is not a valid float", min_angle_char);
         return false;
       }
     }
@@ -262,18 +223,10 @@ bool parseRay(Ray &ray, TiXmlElement* config)
     const char* max_angle_char = horizontal->Attribute("max_angle");
     if (max_angle_char)
     {
-      try
-      {
-        ray.horizontal_max_angle = std::stod(max_angle_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray horizontal max_angle [%s] is out of range: %s", max_angle_char, e.what());
+      try {
+        ray.horizontal_max_angle = strToDouble(max_angle_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray horizontal max_angle [%s] is not a valid float", max_angle_char);
         return false;
       }
     }
@@ -304,37 +257,21 @@ bool parseRay(Ray &ray, TiXmlElement* config)
     const char* resolution_char = vertical->Attribute("resolution");
     if (resolution_char)
     {
-      try
-      {
-        ray.vertical_resolution = std::stod(resolution_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical resolution [%s] is not a valid float: %s", resolution_char, e.what());
+      try {
+        ray.vertical_resolution = strToDouble(resolution_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray vertical resolution [%s] is not a valid float", resolution_char);
         return false;
       }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical resolution [%s] is out of range: %s", resolution_char, e.what());
-        return false;
-      }
-    }   
-    
+    }
+
     const char* min_angle_char = vertical->Attribute("min_angle");
     if (min_angle_char)
     {
-      try
-      {
-        ray.vertical_min_angle = std::stod(min_angle_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical min_angle [%s] is not a valid float: %s", min_angle_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical min_angle [%s] is out of range: %s", min_angle_char, e.what());
+      try {
+        ray.vertical_min_angle = strToDouble(min_angle_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray vertical min_angle [%s] is not a valid float", min_angle_char);
         return false;
       }
     }
@@ -342,18 +279,10 @@ bool parseRay(Ray &ray, TiXmlElement* config)
     const char* max_angle_char = vertical->Attribute("max_angle");
     if (max_angle_char)
     {
-      try
-      {
-        ray.vertical_max_angle = std::stod(max_angle_char);
-      }
-      catch (std::invalid_argument &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical max_angle [%s] is not a valid float: %s", max_angle_char, e.what());
-        return false;
-      }
-      catch (std::out_of_range &e)
-      {
-        CONSOLE_BRIDGE_logError("Ray vertical max_angle [%s] is out of range: %s", max_angle_char, e.what());
+      try {
+        ray.vertical_max_angle = strToDouble(max_angle_char);
+      } catch(std::runtime_error &) {
+        CONSOLE_BRIDGE_logError("Ray vertical max_angle [%s] is not a valid float", max_angle_char);
         return false;
       }
     }

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -112,7 +112,43 @@ TEST(URDF_UNIT_TEST, test_rotation_get_set_rpy_idempotent)
       }
     }
   }
+}
 
+TEST(URDF_UNIT_TEST, test_vector3_simple)
+{
+  urdf::Vector3 vec;
 
+  vec.init("1.0 2.0 3.0");
 
+  EXPECT_EQ(1.0, vec.x);
+  EXPECT_EQ(2.0, vec.y);
+  EXPECT_EQ(3.0, vec.z);
+}
+
+TEST(URDF_UNIT_TEST, test_vector3_bad_string)
+{
+  urdf::Vector3 vec;
+
+  EXPECT_THROW(vec.init("1.0 foo 3.0"), urdf::ParseError);
+}
+
+TEST(URDF_UNIT_TEST, test_vector3_invalid_number)
+{
+  urdf::Vector3 vec;
+
+  EXPECT_THROW(vec.init("1.0 2.10.110 3.0"), urdf::ParseError);
+}
+
+TEST(URDF_UNIT_TEST, test_vector3_not_enough_numbers)
+{
+  urdf::Vector3 vec;
+
+  EXPECT_THROW(vec.init("1.0 2.0"), urdf::ParseError);
+}
+
+TEST(URDF_UNIT_TEST, test_vector3_too_many_numbers)
+{
+  urdf::Vector3 vec;
+
+  EXPECT_THROW(vec.init("1.0 2.0 3.0 4.0"), urdf::ParseError);
 }


### PR DESCRIPTION
The short of it is that `str::stod` is not locale-safe, so instead we use the stream operator imbued as "classic" (C) locale.  This PR depends on https://github.com/ros/urdfdom_headers/pull/42, so it should not be merged until that one is merged/released.  While I was at it, I added a bunch of tests just to ensure we are doing the right thing in various places, mostly surrounding the conversion of strings to doubles.