### PR TITLE
Add in some tests for the strToDouble conversion.

### DIFF
--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -20,7 +20,9 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 # unit test to fix geometry problems
 set(tests
-     urdf_unit_test.cpp)
+     urdf_unit_test.cpp
+     urdf_double_convert.cpp
+)
 
 #################################################
 # Build all the tests

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -20,8 +20,8 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 # unit test to fix geometry problems
 set(tests
-     urdf_unit_test.cpp
      urdf_double_convert.cpp
+     urdf_unit_test.cpp
 )
 
 #################################################

--- a/urdf_parser/test/urdf_double_convert.cpp
+++ b/urdf_parser/test/urdf_double_convert.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include <urdf_model/utils.h>
+
+TEST(URDF_DOUBLE_CONVERT, test_successful_conversion)
+{
+  std::string easy{"1.0"};
+  double conv = urdf::strToDouble(easy.c_str());
+  EXPECT_EQ(1.0, conv);
+
+  std::string scientific{"0.00006"};
+  double sconv = urdf::strToDouble(scientific.c_str());
+  EXPECT_NEAR(0.00006, sconv, 0.00001);
+}
+
+TEST(URDF_DOUBLE_CONVERT, test_failed_conversion)
+{
+  std::string invalid{"foo"};
+  EXPECT_THROW({
+      try {
+        urdf::strToDouble(invalid.c_str());
+    } catch(const std::runtime_error& e) {
+        EXPECT_STREQ("Failed converting string to double", e.what());
+        throw;
+    }
+    }, std::runtime_error);
+}


### PR DESCRIPTION
Note that this only tests that some simple cases do the correct
thing.  We can't reliably check the locale fixing
code because we can't depend on any particular locales being
installed on test machines.

This depends on https://github.com/ros/urdfdom_headers/pull/42, so should not be merged until that one is.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>