### PR TITLE
remove invalid link dir

### DIFF
--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -4,11 +4,6 @@ include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-link_directories(
-  ${PROJECT_BINARY_DIR}/test
-)
-
-
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)


### PR DESCRIPTION
Fixes ros2/urdfdom#10.

The warning in the packaging job is gone: https://ci.ros2.org/job/ci_packaging_osx/31/consoleFull#console-section-21

And the normal CI build still passes the tests: https://ci.ros2.org/job/ci_osx/3543/consoleFull#console-section-23