### PR TITLE
assign correct MaterialPtr to all visuals

### DIFF
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -380,9 +380,7 @@ bool parseVisual(Visual &vis, TiXmlElement *config)
     // try to parse material element in place
     vis.material.reset(new Material());
     if (!parseMaterial(*vis.material, mat, true))
-    {
-      CONSOLE_BRIDGE_logDebug("urdfdom: material has only name, actual material definition may be in the model");
-    }
+      vis.material.reset();
   }
   
   return true;


### PR DESCRIPTION
So far, only the first visual in visual_array got the correct MaterialPtr (from the model) assigned.
All other visual had a default-constructed Material with black color.
This required a work around in rviz, to figure out the correct material colors (#1079 or https://github.com/ros-visualization/rviz/pull/1294/commits/ed3b0b3726fd10783b558c31371ebeb054b00375)