### PR TITLE
Test locale

### DIFF
--- a/.travis/build
+++ b/.travis/build
@@ -28,7 +28,7 @@ sudo make install
 # Retrieve urdfdom_headers
 echo "--> Compiling urdfdom_headers"
 cd "$build_dir"
-$git_clone "git://github.com/isys-vision/colors_not_locales.git"
+$git_clone "git://github.com/isys-vision/urdfdom_headers.git" -b colors_not_locales
 cd "$urdfdom_headers_dir"
 cmake .
 sudo make install

--- a/.travis/build
+++ b/.travis/build
@@ -10,6 +10,9 @@ urdfdom_headers_dir="$build_dir/urdfdom_headers"
 # Shortcuts.
 git_clone="git clone --quiet --recursive"
 
+# create locale for testing
+sudo locale-gen nl_NL.UTF-8
+
 # Create layout.
 rm -rf "$build_dir"
 mkdir -p "$build_dir"
@@ -36,5 +39,4 @@ cd "$root_dir"
 cmake .
 make
 make test ARGS="-VV"
-LANG=nl_NL.UTF-8 make test ARGS="-VV"
 sudo make install

--- a/.travis/build
+++ b/.travis/build
@@ -28,7 +28,7 @@ sudo make install
 # Retrieve urdfdom_headers
 echo "--> Compiling urdfdom_headers"
 cd "$build_dir"
-$git_clone "git://github.com/isys-vision/urdfdom_headers.git" -b colors_not_locales
+$git_clone "git://github.com/ros/urdfdom_headers.git"
 cd "$urdfdom_headers_dir"
 cmake .
 sudo make install

--- a/.travis/build
+++ b/.travis/build
@@ -36,4 +36,5 @@ cd "$root_dir"
 cmake .
 make
 make test ARGS="-VV"
+LANG=nl_NL.UTF-8 make test ARGS="-VV"
 sudo make install

--- a/.travis/build
+++ b/.travis/build
@@ -28,7 +28,7 @@ sudo make install
 # Retrieve urdfdom_headers
 echo "--> Compiling urdfdom_headers"
 cd "$build_dir"
-$git_clone "git://github.com/ros/urdfdom_headers.git"
+$git_clone "git://github.com/isys-vision/colors_not_locales.git"
 cd "$urdfdom_headers_dir"
 cmake .
 sudo make install

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -38,5 +38,11 @@ foreach(GTEST_SOURCE_file ${tests})
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
-  set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240)
+  set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240 ENVIRONMENT LC_ALL=C)
+  
+  add_test(NAME    ${BINARY_NAME}_locale
+           COMMAND ${BINARY_NAME}
+                   --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}_locale.xml)
+
+  set_tests_properties(${BINARY_NAME}_locale PROPERTIES TIMEOUT 240 ENVIRONMENT LC_ALL=nl_NL.UTF-8)
 endforeach()

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -257,3 +257,77 @@ TEST(URDF_UNIT_TEST, parse_link_doubles)
   EXPECT_EQ(0.0012, urdf->links_["l1"]->inertial->iyz);
   EXPECT_EQ(0.908, urdf->links_["l1"]->inertial->izz);
 }
+
+
+TEST(URDF_UNIT_TEST, parse_color_doubles)
+{
+  std::string joint_str =
+    "<robot name=\"test\">"
+    "  <joint name=\"j1\" type=\"fixed\">"
+    "    <parent link=\"l1\"/>"
+    "    <child link=\"l2\"/>"
+    "  </joint>"
+    "  <joint name=\"j2\" type=\"fixed\">"
+    "    <parent link=\"l1\"/>"
+    "    <child link=\"l2\"/>"
+    "  </joint>"
+    "  <link name=\"l1\">"
+    "    <visual>"
+    "      <geometry>"
+    "        <sphere radius=\"1.349\"/>"
+    "      </geometry>"
+    "      <material name=\"\">
+    "        <color rgba=\"1.0 0.65 0.0 0.01\" />"
+    "      </material>"
+    "    </visual>"
+    "    <inertial>"
+    "      <mass value=\"8.4396\"/>"
+    "      <inertia ixx=\"0.087\" ixy=\"0.14\" ixz=\"0.912\" iyy=\"0.763\" iyz=\"0.0012\" izz=\"0.908\"/>"
+    "    </inertial>"
+    "  </link>"
+    "  <link name=\"l2\">"
+    "    <visual>"
+    "      <geometry>"
+    "        <cylinder radius=\"3.349\" length=\"7.5490\"/>"
+    "      </geometry>"
+    "      <material name=\"red ish\">
+    "        <color rgba=\"1 0.0001 0.0 1\" />"
+    "      </material>"
+    "    </visual>"
+    "  </link>"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+
+  EXPECT_EQ(2, urdf->links_.size());
+  EXPECT_EQ(2, urdf->joints_.size());
+
+  EXPECT_EQ(urdf::Geometry::SPHERE, urdf->links_["l1"]->visual->geometry->type);
+  std::shared_ptr<urdf::Sphere> s = std::dynamic_pointer_cast<urdf::Sphere>(urdf->links_["l1"]->visual->geometry);
+  EXPECT_EQ(1.349, s->radius);
+  EXPECT_EQ(1.0, urdf->links_["l1"]->visual->material->color->r);
+  EXPECT_EQ(0.65, urdf->links_["l1"]->visual->material->color->g);
+  EXPECT_EQ(0.0, urdf->links_["l1"]->visual->material->color->b);
+  EXPECT_EQ(0.01, urdf->links_["l1"]->visual->material->color->a);
+  EXPECT_EQ("", urdf->links_["l1"]->visual->material->name);
+  EXPECT_EQ("", urdf->links_["l1"]->visual->material->texture_filename);
+
+  EXPECT_EQ(urdf::Geometry::CYLINDER, urdf->links_["l2"]->visual->geometry->type);
+  std::shared_ptr<urdf::Cylinder> c = std::dynamic_pointer_cast<urdf::Cylinder>(urdf->links_["l2"]->visual->geometry);
+  EXPECT_EQ(3.349, c->radius);
+  EXPECT_EQ(7.5490, c->length);
+  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color->r);
+  EXPECT_EQ(0.0001, urdf->links_["l2"]->visual->material->color->g);
+  EXPECT_EQ(0.0, urdf->links_["l2"]->visual->material->color->b);
+  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color->a);
+  EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material->name);
+  EXPECT_EQ("", urdf->links_["l2"]->visual->material->texture_filename);
+
+  EXPECT_EQ(8.4396, urdf->links_["l1"]->inertial->mass);
+  EXPECT_EQ(0.087, urdf->links_["l1"]->inertial->ixx);
+  EXPECT_EQ(0.14, urdf->links_["l1"]->inertial->ixy);
+  EXPECT_EQ(0.912, urdf->links_["l1"]->inertial->ixz);
+  EXPECT_EQ(0.763, urdf->links_["l1"]->inertial->iyy);
+  EXPECT_EQ(0.0012, urdf->links_["l1"]->inertial->iyz);
+  EXPECT_EQ(0.908, urdf->links_["l1"]->inertial->izz);
+}

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -276,7 +276,7 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
     "      <geometry>"
     "        <sphere radius=\"1.349\"/>"
     "      </geometry>"
-    "      <material name=\"\">
+    "      <material name=\"\">"
     "        <color rgba=\"1.0 0.65 0.0 0.01\" />"
     "      </material>"
     "    </visual>"
@@ -290,7 +290,7 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
     "      <geometry>"
     "        <cylinder radius=\"3.349\" length=\"7.5490\"/>"
     "      </geometry>"
-    "      <material name=\"red ish\">
+    "      <material name=\"red ish\">"
     "        <color rgba=\"1 0.0001 0.0 1\" />"
     "      </material>"
     "    </visual>"
@@ -305,10 +305,10 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   EXPECT_EQ(urdf::Geometry::SPHERE, urdf->links_["l1"]->visual->geometry->type);
   std::shared_ptr<urdf::Sphere> s = std::dynamic_pointer_cast<urdf::Sphere>(urdf->links_["l1"]->visual->geometry);
   EXPECT_EQ(1.349, s->radius);
-  EXPECT_EQ(1.0, urdf->links_["l1"]->visual->material->color->r);
-  EXPECT_EQ(0.65, urdf->links_["l1"]->visual->material->color->g);
-  EXPECT_EQ(0.0, urdf->links_["l1"]->visual->material->color->b);
-  EXPECT_EQ(0.01, urdf->links_["l1"]->visual->material->color->a);
+  EXPECT_EQ(1.0, urdf->links_["l1"]->visual->material->color.r);
+  EXPECT_EQ(0.65, urdf->links_["l1"]->visual->material->color.g);
+  EXPECT_EQ(0.0, urdf->links_["l1"]->visual->material->color.b);
+  EXPECT_EQ(0.01, urdf->links_["l1"]->visual->material->color.a);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->texture_filename);
 
@@ -316,11 +316,11 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   std::shared_ptr<urdf::Cylinder> c = std::dynamic_pointer_cast<urdf::Cylinder>(urdf->links_["l2"]->visual->geometry);
   EXPECT_EQ(3.349, c->radius);
   EXPECT_EQ(7.5490, c->length);
-  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color->r);
-  EXPECT_EQ(0.0001, urdf->links_["l2"]->visual->material->color->g);
-  EXPECT_EQ(0.0, urdf->links_["l2"]->visual->material->color->b);
-  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color->a);
-  EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material->name);
+  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color.r);
+  EXPECT_EQ(0.0001, urdf->links_["l2"]->visual->material->color.g);
+  EXPECT_EQ(0.0, urdf->links_["l2"]->visual->material->color.b);
+  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color.a);
+  EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material.name);
   EXPECT_EQ("", urdf->links_["l2"]->visual->material->texture_filename);
 
   EXPECT_EQ(8.4396, urdf->links_["l1"]->inertial->mass);

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -305,10 +305,10 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   EXPECT_EQ(urdf::Geometry::SPHERE, urdf->links_["l1"]->visual->geometry->type);
   std::shared_ptr<urdf::Sphere> s = std::dynamic_pointer_cast<urdf::Sphere>(urdf->links_["l1"]->visual->geometry);
   EXPECT_EQ(1.349, s->radius);
-  EXPECT_EQ(1.0, urdf->links_["l1"]->visual->material->color.r);
-  EXPECT_EQ(0.65, urdf->links_["l1"]->visual->material->color.g);
-  EXPECT_EQ(0.0, urdf->links_["l1"]->visual->material->color.b);
-  EXPECT_EQ(0.01, urdf->links_["l1"]->visual->material->color.a);
+  EXPECT_FLOAT_EQ(1.0, urdf->links_["l1"]->visual->material->color.r);
+  EXPECT_FLOAT_EQ(0.65, urdf->links_["l1"]->visual->material->color.g);
+  EXPECT_FLOAT_EQ(0.0, urdf->links_["l1"]->visual->material->color.b);
+  EXPECT_FLOAT_EQ(0.01, urdf->links_["l1"]->visual->material->color.a);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->texture_filename);
 
@@ -316,10 +316,10 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   std::shared_ptr<urdf::Cylinder> c = std::dynamic_pointer_cast<urdf::Cylinder>(urdf->links_["l2"]->visual->geometry);
   EXPECT_EQ(3.349, c->radius);
   EXPECT_EQ(7.5490, c->length);
-  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color.r);
-  EXPECT_EQ(0.0001, urdf->links_["l2"]->visual->material->color.g);
-  EXPECT_EQ(0.0, urdf->links_["l2"]->visual->material->color.b);
-  EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color.a);
+  EXPECT_FLOAT_EQ(1.0, urdf->links_["l2"]->visual->material->color.r);
+  EXPECT_FLOAT_EQ(0.0001, urdf->links_["l2"]->visual->material->color.g);
+  EXPECT_FLOAT_EQ(0.0, urdf->links_["l2"]->visual->material->color.b);
+  EXPECT_FLOAT_EQ(1.0, urdf->links_["l2"]->visual->material->color.a);
   EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l2"]->visual->material->texture_filename);
 

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  //use the environment locale so that the unit test can be repeatet with various locales easily
+  // use the environment locale so that the unit test can be repeated with various locales easily
   setlocale(LC_ALL, "");
 
   return RUN_ALL_TESTS();

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -331,3 +331,14 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   EXPECT_EQ(0.0012, urdf->links_["l1"]->inertial->iyz);
   EXPECT_EQ(0.908, urdf->links_["l1"]->inertial->izz);
 }
+
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  //use the environment locale so that the unit test can be repeatet with various locales easily
+  setlocale(LC_ALL, "");
+
+  return RUN_ALL_TESTS();
+}

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -320,7 +320,7 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   EXPECT_EQ(0.0001, urdf->links_["l2"]->visual->material->color.g);
   EXPECT_EQ(0.0, urdf->links_["l2"]->visual->material->color.b);
   EXPECT_EQ(1.0, urdf->links_["l2"]->visual->material->color.a);
-  EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material.name);
+  EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l2"]->visual->material->texture_filename);
 
   EXPECT_EQ(8.4396, urdf->links_["l1"]->inertial->mass);


### PR DESCRIPTION
This PR adds a test for color parsing. To check locale dependent issues it adds the Dutch locale to the travis environment and then runs tests both with LC_ALL=C and LC_ALL=nl_NL.UTF-8

With the current version of urdfdom_headers this is expected to fail for Dutch but not for "Classic". https://github.com/ros/urdfdom_headers/pull/47 should fix it for Dutch (and other European languages)

Please squash on merge