### PR TITLE
Fix windows test compilation, add appveyor script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ if (NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CMAKE_CXX_FLAGS}")
+
 find_package(console_bridge 0.3 REQUIRED)
 include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
 link_directories(${console_bridge_LIBRARY_DIRS})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
   - cd build
   - cmake ..
       -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-      -DEXTRA_CMAKE_CXX_FLAGS="-WX"
+      -DCMAKE_CXX_FLAGS="-WX"
   - cmake --build . --config %CONFIGURATION%
 
 #test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,8 @@ build_script:
       -DEXTRA_CMAKE_CXX_FLAGS="-WX"
   - cmake --build . --config %CONFIGURATION%
 
-test_script:
-  - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
+#test_script:
+#  - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
 
 after_build:
   - cmake --build . --config %CONFIGURATION% --target INSTALL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
   - cd build
   - cmake ..
       -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-      -DCMAKE_CXX_FLAGS="-WX"
+      -DEXTRA_CMAKE_CXX_FLAGS="-WX"
   - cmake --build . --config %CONFIGURATION%
 
 #test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+os:
+  - Visual Studio 2017
+  - Visual Studio 2015
+
+configuration:
+  - Debug
+  - Release
+
+environment:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+install:
+  - vcpkg install tinyxml
+  # console_bridge
+  - git clone https://github.com/ros/console_bridge.git -b master
+  - cd console_bridge
+  - md build
+  - cd build
+  - cmake ..
+  - cmake --build . --target INSTALL
+  - cd ../..
+  # urdfdom_headers
+  - git clone https://github.com/ros/urdfdom_headers.git -b master
+  - cd urdfdom_headers
+  - md build
+  - cd build
+  - cmake ..
+  - cmake --build . --target INSTALL
+  - cd ../..
+build_script:
+  - md build
+  - cd build
+  - cmake ..
+      -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+      -DEXTRA_CMAKE_CXX_FLAGS="-WX"
+  - cmake --build . --config %CONFIGURATION%
+
+test_script:
+  - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
+
+after_build:
+  - cmake --build . --config %CONFIGURATION% --target INSTALL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ configuration:
 
 environment:
   CTEST_OUTPUT_ON_FAILURE: 1
+  CXXFLAGS: -WX
 
 install:
   - vcpkg install tinyxml
@@ -32,7 +33,6 @@ build_script:
   - cd build
   - cmake ..
       -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-      -DEXTRA_CMAKE_CXX_FLAGS="-WX"
   - cmake --build . --config %CONFIGURATION%
 
 #test_script:

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -1,3 +1,11 @@
+//For using the M_PI macro in visual studio it
+//is necessary to define _USE_MATH_DEFINES
+#ifdef _MSC_VER
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#endif
+
 #include <gtest/gtest.h>
 #include <iostream>
 #include <iomanip>

--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -313,10 +313,10 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   EXPECT_EQ(urdf::Geometry::SPHERE, urdf->links_["l1"]->visual->geometry->type);
   std::shared_ptr<urdf::Sphere> s = std::dynamic_pointer_cast<urdf::Sphere>(urdf->links_["l1"]->visual->geometry);
   EXPECT_EQ(1.349, s->radius);
-  EXPECT_FLOAT_EQ(1.0, urdf->links_["l1"]->visual->material->color.r);
-  EXPECT_FLOAT_EQ(0.65, urdf->links_["l1"]->visual->material->color.g);
-  EXPECT_FLOAT_EQ(0.0, urdf->links_["l1"]->visual->material->color.b);
-  EXPECT_FLOAT_EQ(0.01, urdf->links_["l1"]->visual->material->color.a);
+  EXPECT_FLOAT_EQ(1.0f, urdf->links_["l1"]->visual->material->color.r);
+  EXPECT_FLOAT_EQ(0.65f, urdf->links_["l1"]->visual->material->color.g);
+  EXPECT_FLOAT_EQ(0.0f, urdf->links_["l1"]->visual->material->color.b);
+  EXPECT_FLOAT_EQ(0.01f, urdf->links_["l1"]->visual->material->color.a);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l1"]->visual->material->texture_filename);
 
@@ -324,10 +324,10 @@ TEST(URDF_UNIT_TEST, parse_color_doubles)
   std::shared_ptr<urdf::Cylinder> c = std::dynamic_pointer_cast<urdf::Cylinder>(urdf->links_["l2"]->visual->geometry);
   EXPECT_EQ(3.349, c->radius);
   EXPECT_EQ(7.5490, c->length);
-  EXPECT_FLOAT_EQ(1.0, urdf->links_["l2"]->visual->material->color.r);
-  EXPECT_FLOAT_EQ(0.0001, urdf->links_["l2"]->visual->material->color.g);
-  EXPECT_FLOAT_EQ(0.0, urdf->links_["l2"]->visual->material->color.b);
-  EXPECT_FLOAT_EQ(1.0, urdf->links_["l2"]->visual->material->color.a);
+  EXPECT_FLOAT_EQ(1.0f, urdf->links_["l2"]->visual->material->color.r);
+  EXPECT_FLOAT_EQ(0.0001f, urdf->links_["l2"]->visual->material->color.g);
+  EXPECT_FLOAT_EQ(0.0f, urdf->links_["l2"]->visual->material->color.b);
+  EXPECT_FLOAT_EQ(1.0f, urdf->links_["l2"]->visual->material->color.a);
   EXPECT_EQ("red ish", urdf->links_["l2"]->visual->material->name);
   EXPECT_EQ("", urdf->links_["l2"]->visual->material->texture_filename);
 


### PR DESCRIPTION
This adds an appveyor script that exposed some problems compiling the `urdf_unit_test.cpp` test, so I've added `#define _USE_MATH_DEFINES` to fix the `M_PI` problems and fixed some float / double conversion warnings. There's still something wrong with the build, though because it's gettting a bunch of compiler warnings related to "inconsistent dll linkage" and "no object file generated".

* https://ci.appveyor.com/project/scpeters/urdfdom/build/job/3aedk1co0b1y35ry

Once this is working, I'll ask @tfoote to enable appveyor for this repository.