### PR TITLE
Add quaternion in URDF attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 project (urdfdom CXX C)
 
 set (URDF_MAJOR_VERSION 1)
-set (URDF_MINOR_VERSION 0)
-set (URDF_PATCH_VERSION 3)
+set (URDF_MINOR_VERSION 1)
+set (URDF_PATCH_VERSION 0)
 
 set (URDF_VERSION ${URDF_MAJOR_VERSION}.${URDF_MINOR_VERSION}.${URDF_PATCH_VERSION})
 set (URDF_MAJOR_MINOR_VERSION ${URDF_MAJOR_VERSION}.${URDF_MINOR_VERSION})
@@ -45,7 +45,7 @@ find_package(console_bridge 0.3 REQUIRED)
 include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
 link_directories(${console_bridge_LIBRARY_DIRS})
 
-#In Visual Studio a special postfix for 
+#In Visual Studio a special postfix for
 #libraries compiled in debug is used
 if(MSVC)
 set(CMAKE_DEBUG_POSTFIX "d")

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -119,7 +119,7 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
     if (quat_str != NULL)
     {
       try {
-        pose.rotation.initQuaternions(quat_str);
+        pose.rotation.initQuaternion(quat_str);
       }
       catch (ParseError &e) {
         CONSOLE_BRIDGE_logError(e.what());

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -105,10 +105,10 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
     }
 
     const char* rpy_str = xml->Attribute("rpy");
-    const char* quat_str = xml->Attribute("quat");
+    const char* quat_str = xml->Attribute("quat_xyzw");
     if (rpy_str != NULL && quat_str != NULL)
     {
-      CONSOLE_BRIDGE_logError("Both rpy and quat orientations are defined. Use either one or the other.");
+      CONSOLE_BRIDGE_logError("Both rpy and quat_xyzw orientations are defined. Use either one or the other.");
       return false;
     }
 

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -109,6 +109,17 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
     {
       try {
         pose.rotation.init(rpy_str);
+      }
+      catch (ParseError &e) {
+        CONSOLE_BRIDGE_logError(e.what());
+        return false;
+      }
+    }
+    const char* quat_str = xml->Attribute("quat");
+    if (quat_str != NULL)
+    {
+      try {
+        pose.rotation.initQuaternions(quat_str);
       }
       catch (ParseError &e) {
         CONSOLE_BRIDGE_logError(e.what());

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -105,6 +105,13 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
     }
 
     const char* rpy_str = xml->Attribute("rpy");
+    const char* quat_str = xml->Attribute("quat");
+    if (rpy_str != NULL && quat_str != NULL)
+    {
+      CONSOLE_BRIDGE_logError("Both rpy and quat orientations are defined. Use either one or the other.");
+      return false;
+    }
+
     if (rpy_str != NULL)
     {
       try {
@@ -115,7 +122,7 @@ bool parsePose(Pose &pose, TiXmlElement* xml)
         return false;
       }
     }
-    const char* quat_str = xml->Attribute("quat");
+
     if (quat_str != NULL)
     {
       try {

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -17,7 +17,7 @@
   <xs:complexType name="pose">
     <xs:attribute name="xyz" type="xs:string" default="0 0 0" />
     <xs:attribute name="rpy" type="xs:string" default="0 0 0" />
-    <xs:attribute name="quat" type="xs:string" default="0 0 0 1" />
+    <xs:attribute name="quat_xyzw" type="xs:string" default="0 0 0 1" />
   </xs:complexType>
 
   <!-- pose node type -->

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -319,7 +319,7 @@
       <xs:attribute name="name" type="xs:string" use="required" />
 
       <!-- TM: I suggest adding the following attribute. -->
-      <xs:attribute name="version" type="xs:string" default="1.0" />
+      <xs:attribute name="version" type="xs:string" default="1.1.0" />
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -17,6 +17,7 @@
   <xs:complexType name="pose">
     <xs:attribute name="xyz" type="xs:string" default="0 0 0" />
     <xs:attribute name="rpy" type="xs:string" default="0 0 0" />
+    <xs:attribute name="quat" type="xs:string" default="0 0 0 1" />
   </xs:complexType>
 
   <!-- pose node type -->


### PR DESCRIPTION
Fixes #13 

:warning: Depends on https://github.com/ros/urdfdom_headers/pull/51

# Short description
Only `rpy` rotations are supported in `urdf` now. This pull request allows to use quaternions inside of `urdf` files. 

# URDF syntax example
```xml
<origin quat_xyzw="0 0 0.7071 0.7071" xyz="2.5 0 0"/>
```

# How to test
Compile / install modified `urdfdom_headers`
```bash
mkdir -p ~/libraries/urdfdom_headers/build
cd ~/libraries/urdfdom_headers
git clone https://github.com/VictorLamoine/urdfdom_headers.git src
cd build
cmake ../src
sudo make -j4 install
```
Compile / install modified `urdfdom`
```bash
mkdir -p ~/libraries/urdfdom/build
cd ~/libraries/urdfdom
git clone https://github.com/VictorLamoine/urdfdom.git src
cd build
cmake ../src
sudo make -j4 install
```
Change `LD_LIBRARY_PATH` to make sure new `urdfdom` version will be used
```bash
LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH 
```
Compile a simple example package and visualize result in RViz
```bash
mkdir -p ~/urdfdom_test_ws/src
cd ~/urdfdom_test_ws/src
git clone --branch urdfdom_quaternions https://gitlab.com/InstitutMaupertuis/test_robot.git
cd ..
catkin_make
source devel/setup.bash
roslaunch test_robot robot.launch
```

Green suzanne is turned 90° around the Z axis because [the provided quaternion is 0 0 0.7071 0.7071 (xyzw)](
https://gitlab.com/InstitutMaupertuis/test_robot/blob/urdfdom_quaternions/urdf/robot.xacro#L29):
![screenshot_20190225_150719](https://user-images.githubusercontent.com/5566160/53342788-16b89900-390f-11e9-9cc4-628a8995b4fd.png)

# Notes
- The order is `xyzw`, some libraries (Eigen) initialize in the `wxyz` order, so we must document the initialization order.
- Providing a quaternion with less or more than 4 values will lead to an error.
- Providing a non normalized quaternion leads to undefined behavior but the quaternion is normalized after being parsed. This should avoid nasty errors.
- Providing both euler angles and a quaternion will lead to an error.