### PR TITLE
add an explicit float check

### DIFF
--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -127,6 +127,17 @@ TEST(URDF_UNIT_TEST, test_vector3_simple)
   EXPECT_EQ(3.0, vec.z);
 }
 
+TEST(URDF_UNIT_TEST, test_vector3_float)
+{
+  urdf::Vector3 vec;
+
+  vec.init("0.1 0.2 0.3");
+
+  EXPECT_EQ(0.1, vec.x);
+  EXPECT_EQ(0.2, vec.y);
+  EXPECT_EQ(0.3, vec.z);
+}
+
 TEST(URDF_UNIT_TEST, test_vector3_bad_string)
 {
   urdf::Vector3 vec;


### PR DESCRIPTION
There is currently no explicit test for correct float parsing for eg `xyz` vectors

Please feel relieved that I did not find a new regression, just making checks more explicit in light of the discussion on https://github.com/ros/urdfdom/issues/119