### PR TITLE
Add in support for a version tag.

### DIFF
--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -37,12 +37,15 @@
 #ifndef URDF_PARSER_URDF_PARSER_H
 #define URDF_PARSER_URDF_PARSER_H
 
+#include <stdexcept>
 #include <string>
-#include <map>
+#include <vector>
+
 #include <tinyxml.h>
 #include <urdf_model/model.h>
 #include <urdf_model/color.h>
 #include <urdf_world/types.h>
+#include <urdf_model/utils.h>
 
 #include "exportdecl.h"
 
@@ -53,6 +56,87 @@ URDFDOM_DLLAPI std::string values2str(urdf::Vector3 vec);
 URDFDOM_DLLAPI std::string values2str(urdf::Rotation rot);
 URDFDOM_DLLAPI std::string values2str(urdf::Color c);
 URDFDOM_DLLAPI std::string values2str(double d);
+
+// This lives here (rather than in model.cpp) so we can run tests on it.
+class URDFVersion final
+{
+public:
+  explicit URDFVersion(const char *attr)
+  {
+    // If the passed in attribute is NULL, it means it wasn't specified in the
+    // XML, so we just assume version 1.0.
+    if (attr == nullptr)
+    {
+      major_ = 1;
+      minor_ = 0;
+      return;
+    }
+
+    // We accept any of the following strings:
+    // 1
+    // 1.0
+    // 1.0.0
+    std::vector<std::string> split;
+    urdf::split_string(split, std::string(attr), ".");
+    if (split.size() == 2)
+    {
+      major_ = strToUnsigned(split[0].c_str());
+      minor_ = strToUnsigned(split[1].c_str());
+    }
+    else
+    {
+      throw std::runtime_error("The version attribute should be in the form 'x.y'");
+    }
+  }
+
+  bool equal(uint32_t maj, uint32_t min)
+  {
+    return this->major_ == maj && this->minor_ == min;
+  }
+
+  uint32_t getMajor() const
+  {
+    return major_;
+  }
+
+  uint32_t getMinor() const
+  {
+    return minor_;
+  }
+
+private:
+  uint32_t strToUnsigned(const char *str)
+  {
+    if (str[0] == '\0')
+    {
+      // This would get caught below, but we can make a nicer error message
+      throw std::runtime_error("One of the fields of the version attribute is blank");
+    }
+    char *end = const_cast<char *>(str);
+    long value = strtol(str, &end, 10);
+    if (end == str)
+    {
+      // If the pointer didn't move at all, then we couldn't convert any of
+      // the string to an integer.
+      throw std::runtime_error("Version attribute is not an integer");
+    }
+    if (*end != '\0')
+    {
+      // Here, we didn't go all the way to the end of the string, which
+      // means there was junk at the end
+      throw std::runtime_error("Extra characters after the version number");
+    }
+    if (value < 0)
+    {
+      throw std::runtime_error("Version number must be positive");
+    }
+
+    return value;
+  }
+
+  uint32_t major_;
+  uint32_t minor_;
+};
 
 }
 

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -75,7 +75,6 @@ public:
     // We accept any of the following strings:
     // 1
     // 1.0
-    // 1.0.0
     std::vector<std::string> split;
     urdf::split_string(split, std::string(attr), ".");
     if (split.size() == 2)

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -119,6 +119,33 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   }
   model->name_ = std::string(name);
 
+  float version = -1.0;
+  int version_ret = robot_xml->QueryFloatAttribute("version", &version);
+  if (version_ret == TIXML_NO_ATTRIBUTE)
+  {
+    // The attribute didn't exist, so assume 1.0.
+    version = 1.0;
+  }
+  else if (version_ret == TIXML_WRONG_TYPE)
+  {
+    CONSOLE_BRIDGE_logError("Invalid type for 'version' attribute; must be an integer");
+    model.reset();
+    return model;
+  }
+  else if (version_ret != TIXML_SUCCESS)
+  {
+    CONSOLE_BRIDGE_logError("Unknown error getting 'version' attribute");
+    model.reset();
+    return model;
+  }
+
+  if (version != 1.0)
+  {
+    CONSOLE_BRIDGE_logError("Invalid 'version' specified; only version 1.0 is currently supported");
+    model.reset();
+    return model;
+  }
+
   // Get all Material elements
   for (TiXmlElement* material_xml = robot_xml->FirstChildElement("material"); material_xml; material_xml = material_xml->NextSiblingElement("material"))
   {

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 set(tests
      urdf_double_convert.cpp
      urdf_unit_test.cpp
+     urdf_version_test.cpp
 )
 
 #################################################
@@ -39,7 +40,7 @@ foreach(GTEST_SOURCE_file ${tests})
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
   set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240 ENVIRONMENT LC_ALL=C)
-  
+
   add_test(NAME    ${BINARY_NAME}_locale
            COMMAND ${BINARY_NAME}
                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}_locale.xml)

--- a/urdf_parser/test/urdf_version_test.cpp
+++ b/urdf_parser/test/urdf_version_test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <urdf_parser/urdf_parser.h>
+
+TEST(URDF_VERSION, test_version_wrong_type)
+{
+  std::string test_str =
+    "<robot name=\"test\" version=\"foo\">"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
+
+  EXPECT_EQ(urdf, nullptr);
+}
+
+TEST(URDF_VERSION, test_version_unsupported_version)
+{
+  std::string test_str =
+    "<robot name=\"test\" version=\"2\">"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
+
+  EXPECT_EQ(urdf, nullptr);
+}
+
+TEST(URDF_VERSION, test_version_not_specified)
+{
+  std::string test_str =
+    "<robot name=\"test\">"
+    "  <link name=\"l1\"/>"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
+
+  EXPECT_NE(urdf, nullptr);
+}
+
+TEST(URDF_VERSION, test_version_one_int)
+{
+  std::string test_str =
+    "<robot name=\"test\" version=\"1\">"
+    "  <link name=\"l1\"/>"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
+
+  EXPECT_NE(urdf, nullptr);
+}
+
+TEST(URDF_VERSION, test_version_one_float)
+{
+  std::string test_str =
+    "<robot name=\"test\" version=\"1.0\">"
+    "  <link name=\"l1\"/>"
+    "</robot>";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
+
+  EXPECT_NE(urdf, nullptr);
+}

--- a/urdf_parser/test/urdf_version_test.cpp
+++ b/urdf_parser/test/urdf_version_test.cpp
@@ -1,6 +1,30 @@
+#include <iostream>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include <urdf_parser/urdf_parser.h>
+
+#define EXPECT_THROW_OF_TYPE(type, statement, msg)                         \
+  do {                                                                     \
+    try {                                                                  \
+      statement;                                                           \
+    } catch (const type & err) {                                           \
+      if (std::string(err.what()).find(msg) == std::string::npos) {        \
+        FAIL() << "Expected error msg containing:" << std::endl            \
+               << msg << std::endl                                         \
+               << "Saw error msg:" << std::endl                            \
+               << err.what() << std::endl;                                 \
+      }                                                                    \
+    } catch (const std::exception & err) {                                 \
+      FAIL() << "Expected " #type << std::endl                             \
+             << "Saw exception type: " << typeid(err).name() << std::endl; \
+    }                                                                      \
+  } while (0)
+
+#define EXPECT_RUNTIME_THROW(st, msg) \
+  EXPECT_THROW_OF_TYPE(std::runtime_error, st, msg)
+
 
 TEST(URDF_VERSION, test_version_wrong_type)
 {
@@ -45,7 +69,7 @@ TEST(URDF_VERSION, test_version_one_int)
 
   urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
 
-  EXPECT_NE(urdf, nullptr);
+  EXPECT_EQ(urdf, nullptr);
 }
 
 TEST(URDF_VERSION, test_version_one_float)
@@ -58,4 +82,74 @@ TEST(URDF_VERSION, test_version_one_float)
   urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
 
   EXPECT_NE(urdf, nullptr);
+}
+
+TEST(URDF_VERSION_CLASS, test_null_ptr)
+{
+  urdf_export_helpers::URDFVersion vers1(nullptr);
+
+  EXPECT_EQ(vers1.getMajor(), 1);
+  EXPECT_EQ(vers1.getMinor(), 0);
+}
+
+TEST(URDF_VERSION_CLASS, test_correct_string)
+{
+  urdf_export_helpers::URDFVersion vers2("1.0");
+
+  EXPECT_EQ(vers2.getMajor(), 1);
+  EXPECT_EQ(vers2.getMinor(), 0);
+}
+
+TEST(URDF_VERSION_CLASS, test_too_many_dots)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("1.0.0"),
+                       "The version attribute should be in the form 'x.y'");
+}
+
+TEST(URDF_VERSION_CLASS, test_not_enough_numbers)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("1."),
+                       "The version attribute should be in the form 'x.y'");
+}
+
+TEST(URDF_VERSION_CLASS, test_no_major_number)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2(".1"),
+                       "One of the fields of the version attribute is blank");
+}
+
+TEST(URDF_VERSION_CLASS, test_negative_major_number)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("-1.0"),
+                       "Version number must be positive");
+}
+
+TEST(URDF_VERSION_CLASS, test_negative_minor_number)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("1.-1"),
+                       "Version number must be positive");
+}
+
+TEST(URDF_VERSION_CLASS, test_no_numbers)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("abc"),
+                       "The version attribute should be in the form 'x.y'");
+}
+
+TEST(URDF_VERSION_CLASS, test_dots_no_numbers)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("a.c"),
+                       "Version attribute is not an integer");
+}
+
+TEST(URDF_VERSION_CLASS, test_dots_one_number)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("1.c"),
+                       "Version attribute is not an integer");
+}
+
+TEST(URDF_VERSION_CLASS, test_trailing_junk)
+{
+  EXPECT_RUNTIME_THROW(urdf_export_helpers::URDFVersion vers2("1.0~pre6"),
+                       "Extra characters after the version number");
 }


### PR DESCRIPTION
This is already specified by the xsd, so just make sure we
implement it and enforce it in the code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@sloretz @scpeters FYI