### PR TITLE
Find console_bridge without explicit version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,7 @@ if (NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-find_package(console_bridge 0.3 QUIET)
-if (NOT console_bridge_FOUND)
-  find_package(console_bridge 1.0 REQUIRED)
-endif()
+find_package(console_bridge REQUIRED)
 include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
 link_directories(${console_bridge_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,10 @@ if (NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-find_package(console_bridge 0.3 REQUIRED)
+find_package(console_bridge 0.3 QUIET)
+if (NOT console_bridge_FOUND)
+  find_package(console_bridge 1.0 REQUIRED)
+endif()
 include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
 link_directories(${console_bridge_LIBRARY_DIRS})
 


### PR DESCRIPTION
We just released console_bridge 1.0, but urdfdom fails to find it when searching for version `0.3`. This searches for 1.0 if 0.3 is not found.

First noticed the failure in https://github.com/Homebrew/homebrew-core/pull/55355