### PR TITLE
Change output file of urdf_to_graphiz

### DIFF
--- a/urdf_parser/src/urdf_to_graphiz.cpp
+++ b/urdf_parser/src/urdf_to_graphiz.cpp
@@ -91,6 +91,9 @@ int main(int argc, char** argv)
               << "  or OUTPUT.gv & OUTPUT.pdf." << std::endl;
     return -1;
   }
+  if (argc != 3) {
+    std::cerr << "WARNING: OUTPUT not given. This type of usage is deprecated!" << std::endl;
+  }
 
   // get the entire file
   std::string xml_string;

--- a/urdf_parser/src/urdf_to_graphiz.cpp
+++ b/urdf_parser/src/urdf_to_graphiz.cpp
@@ -85,8 +85,10 @@ void printTree(LinkConstSharedPtr link, string file)
 
 int main(int argc, char** argv)
 {
-  if (argc != 2){
-    std::cerr << "Usage: urdf_to_graphiz input.xml" << std::endl;
+  if (argc < 2 || argc > 3) {
+    std::cerr << "Usage: urdf_to_graphiz input.xml [OUTPUT]"
+              << "  Will create either $ROBOT_NAME.gv & $ROBOT_NAME.pdf in CWD"
+              << "  or OUTPUT.gv & OUTPUT.pdf." << std::endl;
     return -1;
   }
 
@@ -106,7 +108,10 @@ int main(int argc, char** argv)
     std::cerr << "ERROR: Model Parsing the xml failed" << std::endl;
     return -1;
   }
-  string output = argv[1];
+
+  string output = robot->getName();
+  if (argc == 3)
+    output = argv[2];
 
   // print entire tree to file
   printTree(robot->getRoot(), output+".gv");

--- a/urdf_parser/src/urdf_to_graphiz.cpp
+++ b/urdf_parser/src/urdf_to_graphiz.cpp
@@ -92,7 +92,10 @@ int main(int argc, char** argv)
     return -1;
   }
   if (argc != 3) {
-    std::cerr << "WARNING: OUTPUT not given. This type of usage is deprecated!" << std::endl;
+    std::cerr << "WARNING: OUTPUT not given. This type of usage is deprecated!"
+              << "Usage: urdf_to_graphiz input.xml [OUTPUT]"
+              << "  Will create either $ROBOT_NAME.gv & $ROBOT_NAME.pdf in CWD"
+              << "  or OUTPUT.gv & OUTPUT.pdf." << std::endl;
   }
 
   // get the entire file

--- a/urdf_parser/src/urdf_to_graphiz.cpp
+++ b/urdf_parser/src/urdf_to_graphiz.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
     std::cerr << "ERROR: Model Parsing the xml failed" << std::endl;
     return -1;
   }
-  string output = robot->getName();
+  string output = argv[1];
 
   // print entire tree to file
   printTree(robot->getRoot(), output+".gv");


### PR DESCRIPTION
Currently `urdf_to_graphiz` writes the pdf to `$ROBOT_NAME.gv`/`$ROBOT_NAME.pdf` in the current working directory. This is problematic especially when using this in scripts, as one would either have to read the XML-file to know where this file was saved or  to read the stdout of `urdf_to_graphiz`

Moreover, it seems more handy to put the pdf in the same directory as the urdf. This way you can find it really easier later on and you don't have to move it to the urdf. Also when there might exist multiple URDFs for the same robot (same robot name) this prevents overwriting of files.

This MR saves the files right beneath the urdf by just appending `.gv` or `.pdf` to the input path.