### PR TITLE
Fix cmake if not compiled with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,6 @@ find_package(urdfdom_headers 1.0 REQUIRED)
 find_package(console_bridge_vendor QUIET) # Provides console_bridge 0.4.0 on platforms without it.
 find_package(console_bridge REQUIRED)
 
-#In Visual Studio a special postfix for libraries compiled in debug is used
-if(MSVC)
-  set(CMAKE_DEBUG_POSTFIX "d")
-endif(MSVC)
-
 # Control where libraries and executables are placed during the build
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")

--- a/cmake/urdfdom-config.cmake.in
+++ b/cmake/urdfdom-config.cmake.in
@@ -11,7 +11,7 @@ foreach(lib @PKG_LIBRARIES@)
   find_library(onelib ${lib}
     PATHS "${@PROJECT_NAME@_DIR}/@RELATIVE_PATH_CMAKE_DIR_TO_PREFIX@/@CMAKE_INSTALL_LIBDIR@"
     NO_DEFAULT_PATH)
-  find_library(onelibd ${lib}@CMAKE_DEBUG_POSTFIX@
+  find_library(onelibd ${lib}d
     PATHS "${@PROJECT_NAME@_DIR}/@RELATIVE_PATH_CMAKE_DIR_TO_PREFIX@/@CMAKE_INSTALL_LIBDIR@"
     NO_DEFAULT_PATH)
   if(onelib-NOTFOUND AND onelibd-NOTFOUND)


### PR DESCRIPTION
If MSVC is not set CMAKE_DEBUG_POSTFIX is empty and the generated
urdfdom-config.cmake finds the normal library as debug library and
generates wrong $<$<CONFIG:Debug>: prefixes.

CMAKE_DEBUG_POSTFIX is only used in urdfdom-config.cmake.in so this
patch removes it completely.