### PR TITLE
Support checking a URDF given on stdin

### DIFF
--- a/urdf_parser/src/check_urdf.cpp
+++ b/urdf_parser/src/check_urdf.cpp
@@ -66,19 +66,27 @@ void printTree(LinkConstSharedPtr link,int level = 0)
 int main(int argc, char** argv)
 {
   if (argc < 2){
-    std::cerr << "Expect URDF xml file to parse" << std::endl;
+    std::cerr << "Expect URDF xml file to parse. Use - for stdin" << std::endl;
     return -1;
   }
 
   std::string xml_string;
-  std::fstream xml_file(argv[1], std::fstream::in);
-  while ( xml_file.good() )
+  if (strcmp(argv[1], "-") == 0)
   {
-    std::string line;
-    std::getline( xml_file, line);
-    xml_string += (line + "\n");
+    // Read from stdin
+    for (std::string line; std::getline(std::cin, line);)
+    {
+      xml_string += (line + "\n");
+    }
+  } else
+  {
+    std::ifstream xml_file(argv[1]);
+    for (std::string line; std::getline(xml_file, line);)
+    {
+      xml_string += (line + "\n");
+    }
+    xml_file.close();
   }
-  xml_file.close();
 
   ModelInterfaceSharedPtr robot = parseURDF(xml_string);
   if (!robot){


### PR DESCRIPTION
Makes it easier to pipe results from xacro, and matches urdfdom_py's behavior
Switch an fstream to an ifstream for clarity
Closes #170