### PR TITLE
Fix missing test_depend on python3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,8 @@
   <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend version_gte="0.2.3">urdfdom_headers</exec_depend>
 
+  <test_depend>python3</test_depend>
+  
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
Gtest `internal-utils.cmake` script [uses the Python3 interpreter](https://github.com/ros/urdfdom/blob/99ec1f99f2d175f07cc26e63082502ee62982dac/urdf_parser/test/gtest/cmake/internal_utils.cmake#L249) however it is not installed by rosdep (on systems that does not ship it by default).

Note that the issue was spotted from the `foxy` branch hence this will require backport.