### PR TITLE
cmake: link liburdfdom_world against liburdfdom_model

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -39,22 +39,20 @@ endif()
 
 add_urdfdom_library(
   LIBNAME
-    urdfdom_world
-  SOURCES
-    src/pose.cpp
-    src/model.cpp
-    src/link.cpp
-    src/joint.cpp
-    src/world.cpp)
-
-add_urdfdom_library(
-  LIBNAME
     urdfdom_model
   SOURCES
     src/pose.cpp
     src/model.cpp
     src/link.cpp
     src/joint.cpp)
+
+add_urdfdom_library(
+  LIBNAME
+    urdfdom_world
+  SOURCES
+    src/world.cpp
+  LINK
+    urdfdom_model)
 
 add_urdfdom_library(
   LIBNAME


### PR DESCRIPTION
This is a simple cleanup of library definition in cmake: instead of linking the same .cpp files into both, `liburdfdom_world` and `liburdfdom_model`, just link the former against the latter.