### PR TITLE
refactor: Improve performance

### DIFF
--- a/urdf_parser/src/check_urdf.cpp
+++ b/urdf_parser/src/check_urdf.cpp
@@ -44,7 +44,7 @@ void printTree(LinkConstSharedPtr link,int level = 0)
 {
   level+=2;
   int count = 0;
-  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); ++child)
   {
     if (*child)
     {

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -98,8 +98,8 @@ bool parseMaterial(Material &material, TiXmlElement *config, bool only_name_is_o
   if (!has_rgb && !has_filename) {
     if (!only_name_is_ok) // no need for an error if only name is ok
     {
-      if (!has_rgb) CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] color has no rgba").c_str());
-      if (!has_filename) CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] not defined in file").c_str());
+      CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] color has no rgba").c_str());
+      CONSOLE_BRIDGE_logError(std::string("Material ["+material.name+"] not defined in file").c_str());
     }
     return false;
   }

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -281,19 +281,19 @@ TiXmlDocument*  exportURDF(const ModelInterface &model)
   doc->LinkEndChild(robot);
 
 
-  for (std::map<std::string, MaterialSharedPtr>::const_iterator m=model.materials_.begin(); m!=model.materials_.end(); m++)
+  for (std::map<std::string, MaterialSharedPtr>::const_iterator m=model.materials_.begin(); m!=model.materials_.end(); ++m)
   {
     CONSOLE_BRIDGE_logDebug("urdfdom: exporting material [%s]\n",m->second->name.c_str());
     exportMaterial(*(m->second), robot);
   }
 
-  for (std::map<std::string, LinkSharedPtr>::const_iterator l=model.links_.begin(); l!=model.links_.end(); l++)  
+  for (std::map<std::string, LinkSharedPtr>::const_iterator l=model.links_.begin(); l!=model.links_.end(); ++l)  
   {
     CONSOLE_BRIDGE_logDebug("urdfdom: exporting link [%s]\n",l->second->name.c_str());
     exportLink(*(l->second), robot);
   }
   	
-  for (std::map<std::string, JointSharedPtr>::const_iterator j=model.joints_.begin(); j!=model.joints_.end(); j++)  
+  for (std::map<std::string, JointSharedPtr>::const_iterator j=model.joints_.begin(); j!=model.joints_.end(); ++j)  
   {
     CONSOLE_BRIDGE_logDebug("urdfdom: exporting joint [%s]\n",j->second->name.c_str());
     exportJoint(*(j->second), robot);

--- a/urdf_parser/src/urdf_to_graphviz.cpp
+++ b/urdf_parser/src/urdf_to_graphviz.cpp
@@ -44,14 +44,14 @@ using namespace std;
 void addChildLinkNames(LinkConstSharedPtr link, ofstream& os)
 {
   os << "\"" << link->name << "\" [label=\"" << link->name << "\"];" << endl;
-  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); ++child)
     addChildLinkNames(*child, os);
 }
 
 void addChildJointNames(LinkConstSharedPtr link, ofstream& os)
 {
   double r, p, y;
-  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
+  for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); ++child){
     (*child)->parent_joint->parent_to_joint_origin_transform.rotation.getRPY(r,p,y);
     os << "\"" << link->name << "\" -> \"" << (*child)->parent_joint->name 
        << "\" [label=\"xyz: "


### PR DESCRIPTION
For non-primitive types, using prefix ++/-- operator is faster.

And two not necessary if condition are removed.