### PR TITLE
CMakeLists.txt: Some fixes for Relocatable package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(MSVC OR MSVC90 OR MSVC10)
   set(MSVC ON)
 endif (MSVC OR MSVC90 OR MSVC10)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(tinyxml2_vendor QUIET)
 find_package(TinyXML2 REQUIRED)

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -75,9 +75,9 @@ target_include_directories(urdf_parser INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(urdf_parser INTERFACE
-  urdfdom_model
-  urdfdom_sensor
-  urdfdom_world)
+  urdfdom::urdfdom_model
+  urdfdom::urdfdom_sensor
+  urdfdom::urdfdom_world)
 
 # --------------------------------
 


### PR DESCRIPTION
The overall rationale is, that the current behavior is not well suited for cross-compiling or relocation of the package. This
commit shall address some of the issues found. 

There are some absolute path in the generation of the .cmake files which ruin the creation of relocatable packages.
Fixing:
 * CMAKE_MODULE_PATH append instead of replacement
 * Do not expose TinyXML Path (private instead of public)
 * INTERFACE use relative path instead of ${CMAKE_INSTALL_INCLUDEDIR}

See also

https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#creating-relocatable-packages

for reference.

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>