### PR TITLE
Remove tinyxml2 from public dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ add_subdirectory(urdf_parser)
 
 set(PKG_NAME ${PROJECT_NAME})
 set(PKG_LIBRARIES urdfdom_sensor urdfdom_model_state urdfdom_model urdfdom_world)
-set(PKG_DEPENDS TinyXML2 urdfdom_headers console_bridge)
+set(PKG_DEPENDS urdfdom_headers)
 set(PKG_EXPORTS urdfdom)
 set(cmake_conf_file "cmake/urdfdom-config")
 include(CMakePackageConfigHelpers)
@@ -86,16 +86,11 @@ install(FILES
   DESTINATION ${CMAKE_CONFIG_INSTALL_DIR}
 )
 
-# Some operating systems (like Ubuntu 22.04) do not provide a default
-# way to find TinyXML2.  For that reason, this package provides it
-install(FILES cmake/FindTinyXML2.cmake
-  DESTINATION ${CMAKE_CONFIG_INSTALL_DIR})
-
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
 # Make the package config file
 set(PKG_DESC "Unified Robot Description Format")
-set(PKG_DEPENDS "tinyxml2 urdfdom_headers console_bridge") # make the list separated by spaces instead of ;
+set(PKG_DEPENDS "urdfdom_headers") # make the list separated by spaces instead of ;
 set(PKG_URDF_LIBS "-lurdfdom_sensor -lurdfdom_model_state -lurdfdom_model -lurdfdom_world")
 set(pkg_conf_file "cmake/pkgconfig/urdfdom.pc")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${pkg_conf_file}.in" "${CMAKE_BINARY_DIR}/${pkg_conf_file}" @ONLY)

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -10,8 +10,10 @@ macro(add_urdfdom_library)
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
   target_link_libraries(${add_urdfdom_library_LIBNAME} PUBLIC
     ${add_urdfdom_library_LINK}
-    ${console_bridge_link_libs}
     ${urdfdom_headers_link_libs}
+  )
+  target_link_libraries(${add_urdfdom_library_LIBNAME} PRIVATE
+    ${console_bridge_link_libs}
     tinyxml2::tinyxml2
   )
   if(NOT CMAKE_CXX_STANDARD)

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -41,7 +41,6 @@
 #include <string>
 #include <vector>
 
-#include <tinyxml2.h>
 #include <urdf_model/model.h>
 #include <urdf_model/color.h>
 #include <urdf_model/utils.h>
@@ -50,6 +49,13 @@
 #include <urdf_world/types.h>
 
 #include "exportdecl.h"
+
+namespace tinyxml2{
+  // Forward declaration for APIs that use TinyXML2 structures.
+  // That way, we don't have to export a TinyXML2 dependency.
+  class XMLDocument;
+  class XMLElement;
+}
 
 namespace urdf_export_helpers {
 

--- a/urdf_parser/src/check_urdf.cpp
+++ b/urdf_parser/src/check_urdf.cpp
@@ -35,6 +35,8 @@
 /* Author: Wim Meeussen */
 
 #include "urdf_parser/urdf_parser.h"
+
+#include <cstring>
 #include <iostream>
 #include <fstream>
 

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -40,6 +40,7 @@
 #include <string>
 #include "urdf_parser/urdf_parser.h"
 #include <console_bridge/console.h>
+#include <tinyxml2.h>
 
 namespace urdf{
 


### PR DESCRIPTION
That way, we don't have to export the tinyxml2 dependencies to downstream consumers.  It is just a private dependency at that point.

Based on the code in https://github.com/SMillerDev/urdfdom/commit/092b57c20bca37d1d81eaa6da6b08a7bebb04662

Closes #189

@scpeters @sloretz Thoughts from both of you appreciated.

@traversaro If you have time, any testing you can do on this is highly appreciated.