### PR TITLE
Fix build with cmake 3.30

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -75,9 +75,9 @@ target_include_directories(urdf_parser INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(urdf_parser INTERFACE
-  urdfdom::urdfdom_model
-  urdfdom::urdfdom_sensor
-  urdfdom::urdfdom_world)
+  urdfdom_model
+  urdfdom_sensor
+  urdfdom_world)
 
 # --------------------------------
 


### PR DESCRIPTION
Remove `urdfdom::` target prefix.

Fixes #203.

Thanks to @oysstu for the report and suggested fix.