### PR TITLE
Add ALIAS targets for urdfdom libraries

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -5,6 +5,7 @@ macro(add_urdfdom_library)
 
   add_library(${add_urdfdom_library_LIBNAME} SHARED
     ${add_urdfdom_library_SOURCES})
+  add_library(urdfdom::${add_urdfdom_library_LIBNAME} ALIAS ${add_urdfdom_library_LIBNAME})
   target_include_directories(${add_urdfdom_library_LIBNAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")


### PR DESCRIPTION
Fix https://github.com/ros/urdfdom/issues/203 . This ensure that the library can also be used easily via CMake's FetchContent in a way consistent with using the library via `find_package(urdfdom)` , see https://github.com/ament/ament_cmake/issues/351 for some reference on this.