### PR TITLE
Fix 20ne.js deprecation into system.yaml

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -37,7 +37,7 @@ jobs:
               cxx: "g++",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies on ubuntu
         if: startsWith(matrix.config.name, 'Ubuntu')


### PR DESCRIPTION
node.js <20 are deprecated.
action/checkout v4 use node.js version 20