### PR TITLE
Update system.yaml

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -31,13 +31,13 @@ jobs:
             }
           - {
               name: "Ubuntu Focal GCC",
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               build_type: "Release",
               cc: "gcc",
               cxx: "g++",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies on ubuntu
         if: startsWith(matrix.config.name, 'Ubuntu')


### PR DESCRIPTION
ubuntu 20.04 will reach the end of its standard support on May 31, 2025
actions/checkout@v2 use deprecate node.js version 