### PR TITLE
Relax the version compatibility for urdfdom_headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(tinyxml2_vendor QUIET)
 find_package(TinyXML2 REQUIRED)
 
-find_package(urdfdom_headers 1.0 REQUIRED)
+find_package(urdfdom_headers REQUIRED)
 find_package(console_bridge_vendor QUIET) # Provides console_bridge 0.4.0 on platforms without it.
 find_package(console_bridge REQUIRED)
 


### PR DESCRIPTION
That is, newer versions of urdfdom_headers should be just fine, so don't specify a version here.

This should fix https://github.com/ros2/ros2/issues/1705

@fujitatomoya Since I can't reproduce this, can you give this PR a try and see if it fixes things for you?