### PR TITLE
Revert "Quaternion in urdf (PR123 new attempt) (#194)"

### DIFF
--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -107,28 +107,10 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml)
     }
 
     const char* rpy_str = xml->Attribute("rpy");
-    const char* quat_str = xml->Attribute("quat_xyzw");
-    if (rpy_str != NULL && quat_str != NULL)
-    {
-      CONSOLE_BRIDGE_logError("Both rpy and quat_xyzw orientations are defined. Use either one or the other.");
-      return false;
-    }
-        
     if (rpy_str != NULL)
     {
       try {
         pose.rotation.init(rpy_str);
-      }
-      catch (ParseError &e) {
-        CONSOLE_BRIDGE_logError(e.what());
-        return false;
-      }
-    }
-    
-    if (quat_str != NULL)
-    {
-      try {
-        pose.rotation.initQuaternion(quat_str);
       }
       catch (ParseError &e) {
         CONSOLE_BRIDGE_logError(e.what());

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -27,7 +27,6 @@
   <xs:complexType name="pose">
     <xs:attribute name="xyz" type="xs:string" default="0 0 0" />
     <xs:attribute name="rpy" type="xs:string" default="0 0 0" />
-    <xs:attribute name="quat_xyzw" type="xs:string" default="0 0 0 1" />
   </xs:complexType>
 
   <!-- pose node type -->


### PR DESCRIPTION
This reverts commit 92eb196117a3b99e57adb888d9599473867ed186.

Since #194 was already tagged without updating the schema version (see #230), I think we should revert the change and tag it in 5.0.4 while we address the schema versioning issues.