### PR TITLE
Support quaternions in URDF 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(TinyXML2 REQUIRED)
 
-find_package(urdfdom_headers REQUIRED)
+find_package(urdfdom_headers 2.0.2 REQUIRED)
 find_package(console_bridge_vendor QUIET) # Provides console_bridge 0.4.0 on platforms without it.
 find_package(console_bridge REQUIRED)
 

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -94,6 +94,10 @@ public:
     }
   }
 
+  explicit URDFVersion(uint32_t major, uint32_t minor)
+    : major_(major), minor_(minor)
+  {}
+
   bool equal(uint32_t maj, uint32_t min)
   {
     return this->major_ == maj && this->minor_ == min;

--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -99,6 +99,28 @@ public:
     return this->major_ == maj && this->minor_ == min;
   }
 
+  // equivalent to greater or equal >=
+  bool at_least(uint32_t maj, uint32_t min) const
+  {
+    return this->major_ > maj || (this->major_ == maj && this->minor_ >= min);
+  }
+
+  // equivalent to lesser or equal <=
+  bool at_most(uint32_t maj, uint32_t min) const
+  {
+    return this->major_ < maj || (this->major_ == maj && this->minor_ <= min);
+  }
+
+  bool greater_than(uint32_t maj, uint32_t min) const
+  {
+    return this->major_ > maj || (this->major_ == maj && this->minor_ > min);
+  }
+
+  bool less_than(uint32_t maj, uint32_t min) const
+  {
+    return this->major_ < maj || (this->major_ == maj && this->minor_ < min);
+  }
+
   uint32_t getMajor() const
   {
     return major_;

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -334,7 +334,8 @@ bool parseJointMimic(JointMimic &jm, tinyxml2::XMLElement* config)
   return true;
 }
 
-bool parseJoint(Joint &joint, tinyxml2::XMLElement* config)
+bool parseJoint(Joint &joint, tinyxml2::XMLElement* config,
+                const urdf_export_helpers::URDFVersion version)
 {
   joint.clear();
 
@@ -356,7 +357,7 @@ bool parseJoint(Joint &joint, tinyxml2::XMLElement* config)
   }
   else
   {
-    if (!parsePoseInternal(joint.parent_to_joint_origin_transform, origin_xml))
+    if (!parsePoseInternal(joint.parent_to_joint_origin_transform, origin_xml, version))
     {
       joint.parent_to_joint_origin_transform.clear();
       CONSOLE_BRIDGE_logError("Malformed parent origin element for joint [%s]", joint.name.c_str());

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -266,7 +266,8 @@ GeometrySharedPtr parseGeometry(tinyxml2::XMLElement *g)
   return GeometrySharedPtr();
 }
 
-bool parseInertial(Inertial &i, tinyxml2::XMLElement *config)
+bool parseInertial(Inertial &i, tinyxml2::XMLElement *config,
+                   const urdf_export_helpers::URDFVersion version)
 {
   i.clear();
 
@@ -274,7 +275,7 @@ bool parseInertial(Inertial &i, tinyxml2::XMLElement *config)
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o)
   {
-    if (!parsePoseInternal(i.origin, o))
+    if (!parsePoseInternal(i.origin, o, version))
       return false;
   }
 
@@ -346,14 +347,15 @@ bool parseInertial(Inertial &i, tinyxml2::XMLElement *config)
   return true;
 }
 
-bool parseVisual(Visual &vis, tinyxml2::XMLElement *config)
+bool parseVisual(Visual &vis, tinyxml2::XMLElement *config,
+                 const urdf_export_helpers::URDFVersion version)
 {
   vis.clear();
 
   // Origin
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o) {
-    if (!parsePoseInternal(vis.origin, o))
+    if (!parsePoseInternal(vis.origin, o, version))
       return false;
   }
 
@@ -388,14 +390,15 @@ bool parseVisual(Visual &vis, tinyxml2::XMLElement *config)
   return true;
 }
 
-bool parseCollision(Collision &col, tinyxml2::XMLElement* config)
+bool parseCollision(Collision &col, tinyxml2::XMLElement* config,
+                    const urdf_export_helpers::URDFVersion version)
 {
   col.clear();
 
   // Origin
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o) {
-    if (!parsePoseInternal(col.origin, o))
+    if (!parsePoseInternal(col.origin, o, version))
       return false;
   }
 
@@ -412,7 +415,8 @@ bool parseCollision(Collision &col, tinyxml2::XMLElement* config)
   return true;
 }
 
-bool parseLink(Link &link, tinyxml2::XMLElement* config)
+bool parseLink(Link &link, tinyxml2::XMLElement* config,
+               const urdf_export_helpers::URDFVersion version)
 {
 
   link.clear();
@@ -430,7 +434,7 @@ bool parseLink(Link &link, tinyxml2::XMLElement* config)
   if (i)
   {
     link.inertial.reset(new Inertial());
-    if (!parseInertial(*link.inertial, i))
+    if (!parseInertial(*link.inertial, i, version))
     {
       CONSOLE_BRIDGE_logError("Could not parse inertial element for Link [%s]", link.name.c_str());
       return false;
@@ -443,7 +447,7 @@ bool parseLink(Link &link, tinyxml2::XMLElement* config)
 
     VisualSharedPtr vis;
     vis.reset(new Visual());
-    if (parseVisual(*vis, vis_xml))
+    if (parseVisual(*vis, vis_xml, version))
     {
       link.visual_array.push_back(vis);
     }
@@ -465,7 +469,7 @@ bool parseLink(Link &link, tinyxml2::XMLElement* config)
   {
     CollisionSharedPtr col;
     col.reset(new Collision());
-    if (parseCollision(*col, col_xml))
+    if (parseCollision(*col, col_xml, version))
     {
       link.collision_array.push_back(col);
     }

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -45,8 +45,10 @@
 namespace urdf{
 
 bool parseMaterial(Material &material, tinyxml2::XMLElement *config, bool only_name_is_ok);
-bool parseLink(Link &link, tinyxml2::XMLElement *config);
-bool parseJoint(Joint &joint, tinyxml2::XMLElement *config);
+bool parseLink(Link &link, tinyxml2::XMLElement *config,
+               const urdf_export_helpers::URDFVersion version);
+bool parseJoint(Joint &joint, tinyxml2::XMLElement *config,
+                const urdf_export_helpers::URDFVersion version);
 
 ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
 {
@@ -122,6 +124,10 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   }
   model->name_ = std::string(name);
 
+  // Creating URDFVersion from a string can throw exceptions, so create variables here to store the
+  // major and minor versions and then reconstruct a URDFVersion in this scope.
+  uint32_t major_version = 1;
+  uint32_t minor_version = 0;
   try
   {
     urdf_export_helpers::URDFVersion version(robot_xml->Attribute("version"));
@@ -129,6 +135,8 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     {
       throw std::runtime_error("Invalid 'version' specified; versions 1.0 to 1.1 are currently supported");
     }
+    major_version = version.getMajor();
+    minor_version = version.getMajor();
   }
   catch (const std::runtime_error & err)
   {
@@ -136,6 +144,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     model.reset();
     return model;
   }
+  urdf_export_helpers::URDFVersion version(major_version, minor_version);
 
   // Get all Material elements
   for (tinyxml2::XMLElement* material_xml = robot_xml->FirstChildElement("material"); material_xml; material_xml = material_xml->NextSiblingElement("material"))
@@ -173,7 +182,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     link.reset(new Link);
 
     try {
-      parseLink(*link, link_xml);
+      parseLink(*link, link_xml, version);
       if (model->getLink(link->name))
       {
         CONSOLE_BRIDGE_logError("link '%s' is not unique.", link->name.c_str());
@@ -215,7 +224,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
     JointSharedPtr joint;
     joint.reset(new Joint);
 
-    if (parseJoint(*joint, joint_xml))
+    if (parseJoint(*joint, joint_xml, version))
     {
       if (model->getJoint(joint->name))
       {

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -125,9 +125,9 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
   try
   {
     urdf_export_helpers::URDFVersion version(robot_xml->Attribute("version"));
-    if (!version.equal(1, 0))
+    if (version.less_than(1, 0) || version.greater_than(1, 1))
     {
-      throw std::runtime_error("Invalid 'version' specified; only version 1.0 is currently supported");
+      throw std::runtime_error("Invalid 'version' specified; versions 1.0 to 1.1 are currently supported");
     }
   }
   catch (const std::runtime_error & err)

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -136,7 +136,7 @@ ModelInterfaceSharedPtr  parseURDF(const std::string &xml_string)
       throw std::runtime_error("Invalid 'version' specified; versions 1.0 to 1.1 are currently supported");
     }
     major_version = version.getMajor();
-    minor_version = version.getMajor();
+    minor_version = version.getMinor();
   }
   catch (const std::runtime_error & err)
   {

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -107,10 +107,28 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml)
     }
 
     const char* rpy_str = xml->Attribute("rpy");
+    const char* quat_str = xml->Attribute("quat_xyzw");
+    if (rpy_str != NULL && quat_str != NULL)
+    {
+      CONSOLE_BRIDGE_logError("Both rpy and quat_xyzw orientations are defined. Use either one or the other.");
+      return false;
+    }
+
     if (rpy_str != NULL)
     {
       try {
         pose.rotation.init(rpy_str);
+      }
+      catch (ParseError &e) {
+        CONSOLE_BRIDGE_logError(e.what());
+        return false;
+      }
+    }
+
+    if (quat_str != NULL)
+    {
+      try {
+        pose.rotation.initQuaternion(quat_str);
       }
       catch (ParseError &e) {
         CONSOLE_BRIDGE_logError(e.what());

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -89,7 +89,8 @@ std::string values2str(double d)
 
 namespace urdf{
 
-bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml)
+bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
+                       const urdf_export_helpers::URDFVersion version)
 {
   pose.clear();
   if (xml)

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -109,8 +109,10 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
 
     const char* rpy_str = xml->Attribute("rpy");
     const char* quat_str = xml->Attribute("quat_xyzw");
-    if (rpy_str != NULL && quat_str != NULL)
-    {
+    if (version.less_than(1, 1) && quat_str != NULL) {
+      CONSOLE_BRIDGE_logWarn("Ignoring quat_xyzw attribute requiring URDF version 1.1 since specified version is 1.0.");
+    }
+    else if (rpy_str != NULL && quat_str != NULL) {
       CONSOLE_BRIDGE_logError("Both rpy and quat_xyzw orientations are defined. Use either one or the other.");
       return false;
     }
@@ -126,8 +128,7 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
       }
     }
 
-    if (quat_str != NULL)
-    {
+    if (version.at_least(1, 1) && quat_str != NULL) {
       try {
         pose.rotation.initQuaternion(quat_str);
       }

--- a/urdf_parser/src/pose.hpp
+++ b/urdf_parser/src/pose.hpp
@@ -37,8 +37,11 @@
 #include <urdf_model/pose.h>
 #include <tinyxml2.h>
 
+#include "urdf_parser/urdf_parser.h"
+
 namespace urdf {
 
-URDFDOM_DLLAPI bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml);
+URDFDOM_DLLAPI bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
+                                      const urdf_export_helpers::URDFVersion version);
 
 }

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -16,6 +16,7 @@ execute_process(COMMAND cmake -E make_directory ${CMAKE_BINARY_DIR}/test_results
 # unit test to fix geometry problems
 set(tests
      urdf_double_convert.cpp
+     urdf_schema_quaternion_test.cpp
      urdf_unit_test.cpp
      urdf_version_test.cpp
 )

--- a/urdf_parser/test/urdf_schema_quaternion_test.cpp
+++ b/urdf_parser/test/urdf_schema_quaternion_test.cpp
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <vector>
+
+#include "urdf_model/pose.h"
+#include "urdf_parser/urdf_parser.h"
+
+TEST(URDF_UNIT_TEST, parse_rot_rpy_version_1_0)
+{
+  std::string joint_str = R"urdf(
+    <robot name="rot_rpy" version="1.0">
+      <joint name="j1" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+        <origin xyz="0 0 0" rpy="1.5707963 0 1.5707963"/>
+      </joint>
+      <joint name="j2" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+      </joint>
+      <link name="l1"/>
+      <link name="l2"/>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+
+  EXPECT_EQ(2u, urdf->links_.size());
+  EXPECT_EQ(2u, urdf->joints_.size());
+  EXPECT_EQ("rot_rpy", urdf->name_);
+
+  const urdf::Rotation &j1_rot = urdf->joints_["j1"]->parent_to_joint_origin_transform.rotation;
+  double x, y, z, w;
+  j1_rot.getQuaternion(x, y, z, w);
+
+  const double tol = 1e-6;
+  EXPECT_NEAR(0.5, x, tol);
+  EXPECT_NEAR(0.5, y, tol);
+  EXPECT_NEAR(0.5, z, tol);
+  EXPECT_NEAR(0.5, w, tol);
+}
+
+TEST(URDF_UNIT_TEST, parse_rot_quat_ignored_version_1_0)
+{
+  std::string joint_str = R"urdf(
+    <robot name="rot_quat_ignored" version="1.0">
+      <joint name="j1" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+        <origin xyz="0 0 0" quat_xyzw="0.5 0.5 0.5 0.5"/>
+      </joint>
+      <joint name="j2" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+      </joint>
+      <link name="l1"/>
+      <link name="l2"/>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+
+  EXPECT_EQ(2u, urdf->links_.size());
+  EXPECT_EQ(2u, urdf->joints_.size());
+  EXPECT_EQ("rot_quat_ignored", urdf->name_);
+
+  const urdf::Rotation &j1_rot = urdf->joints_["j1"]->parent_to_joint_origin_transform.rotation;
+  double x, y, z, w;
+  j1_rot.getQuaternion(x, y, z, w);
+
+  // the quaternion string is ignored since the version is 1.0
+  // expect identity rotation
+  EXPECT_DOUBLE_EQ(0.0, x);
+  EXPECT_DOUBLE_EQ(0.0, y);
+  EXPECT_DOUBLE_EQ(0.0, z);
+  EXPECT_DOUBLE_EQ(1.0, w);
+}
+
+TEST(URDF_UNIT_TEST, parse_rot_quat_version_1_1)
+{
+  std::string joint_str = R"urdf(
+    <robot name="rot_quat" version="1.1">
+      <joint name="j1" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+        <origin xyz="0 0 0" quat_xyzw="0.5 0.5 0.5 0.5"/>
+      </joint>
+      <joint name="j2" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+      </joint>
+      <link name="l1"/>
+      <link name="l2"/>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+
+  EXPECT_EQ(2u, urdf->links_.size());
+  EXPECT_EQ(2u, urdf->joints_.size());
+  EXPECT_EQ("rot_quat", urdf->name_);
+
+  const urdf::Rotation &j1_rot = urdf->joints_["j1"]->parent_to_joint_origin_transform.rotation;
+  double x, y, z, w;
+  j1_rot.getQuaternion(x, y, z, w);
+
+  EXPECT_DOUBLE_EQ(0.5, x);
+  EXPECT_DOUBLE_EQ(0.5, y);
+  EXPECT_DOUBLE_EQ(0.5, z);
+  EXPECT_DOUBLE_EQ(0.5, w);
+}
+
+TEST(URDF_UNIT_TEST, parse_rot_both_quat_ignored_version_1_0)
+{
+  std::string joint_str = R"urdf(
+    <robot name="rot_both_quat_ignored" version="1.0">
+      <joint name="j1" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+        <origin xyz="0 0 0" rpy="0 0 0" quat_xyzw="0.5 0.5 0.5 0.5"/>
+      </joint>
+      <joint name="j2" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+      </joint>
+      <link name="l1"/>
+      <link name="l2"/>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+
+  EXPECT_EQ(2u, urdf->links_.size());
+  EXPECT_EQ(2u, urdf->joints_.size());
+  EXPECT_EQ("rot_both_quat_ignored", urdf->name_);
+
+  const urdf::Rotation &j1_rot = urdf->joints_["j1"]->parent_to_joint_origin_transform.rotation;
+  double x, y, z, w;
+  j1_rot.getQuaternion(x, y, z, w);
+
+  // the quaternion string is ignored since the version is 1.0
+  // expect identity rotation
+  EXPECT_DOUBLE_EQ(0.0, x);
+  EXPECT_DOUBLE_EQ(0.0, y);
+  EXPECT_DOUBLE_EQ(0.0, z);
+  EXPECT_DOUBLE_EQ(1.0, w);
+}
+
+TEST(URDF_UNIT_TEST, parse_rot_both_error_version_1_1)
+{
+  std::string joint_str = R"urdf(
+    <robot name="rot_both_error" version="1.1">
+      <joint name="j1" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+        <origin xyz="0 0 0" rpy="0 0 0" quat_xyzw="0.5 0.5 0.5 0.5"/>
+      </joint>
+      <joint name="j2" type="fixed">
+        <parent link="l1"/>
+        <child link="l2"/>
+      </joint>
+      <link name="l1"/>
+      <link name="l2"/>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(joint_str);
+  EXPECT_EQ(nullptr, urdf);
+}
+
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // use the environment locale so that the unit test can be repeated with various locales easily
+  setlocale(LC_ALL, "");
+
+  return RUN_ALL_TESTS();
+}

--- a/urdf_parser/test/urdf_version_test.cpp
+++ b/urdf_parser/test/urdf_version_test.cpp
@@ -40,7 +40,7 @@ TEST(URDF_VERSION, test_version_wrong_type)
 TEST(URDF_VERSION, test_version_unsupported_version)
 {
   std::string test_str =
-    "<robot name=\"test\" version=\"2\">"
+    "<robot name=\"test\" version=\"2.0\">"
     "</robot>";
 
   urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(test_str);
@@ -90,6 +90,46 @@ TEST(URDF_VERSION_CLASS, test_null_ptr)
 
   EXPECT_EQ(vers1.getMajor(), 1u);
   EXPECT_EQ(vers1.getMinor(), 0u);
+}
+
+TEST(URDF_VERSION_CLASS, numeric_constructor)
+{
+  urdf_export_helpers::URDFVersion vers1(1, 0);
+
+  EXPECT_EQ(vers1.getMajor(), 1u);
+  EXPECT_EQ(vers1.getMinor(), 0u);
+}
+
+TEST(URDF_VERSION_CLASS, comparison)
+{
+  urdf_export_helpers::URDFVersion vers1(1, 1);
+
+  EXPECT_FALSE(vers1.equal(0, 0));
+  EXPECT_TRUE(vers1.equal(1, 1));
+
+  EXPECT_TRUE(vers1.at_least(0, 0));
+  EXPECT_TRUE(vers1.at_least(0, 1));
+  EXPECT_TRUE(vers1.at_least(1, 0));
+  EXPECT_TRUE(vers1.at_least(1, 1));
+  EXPECT_FALSE(vers1.at_least(2, 0));
+
+  EXPECT_TRUE(vers1.greater_than(0, 0));
+  EXPECT_TRUE(vers1.greater_than(0, 1));
+  EXPECT_TRUE(vers1.greater_than(1, 0));
+  EXPECT_FALSE(vers1.greater_than(1, 1));
+  EXPECT_FALSE(vers1.greater_than(2, 0));
+
+  EXPECT_FALSE(vers1.at_most(0, 0));
+  EXPECT_FALSE(vers1.at_most(0, 1));
+  EXPECT_FALSE(vers1.at_most(1, 0));
+  EXPECT_TRUE(vers1.at_most(1, 1));
+  EXPECT_TRUE(vers1.at_most(2, 0));
+
+  EXPECT_FALSE(vers1.less_than(0, 0));
+  EXPECT_FALSE(vers1.less_than(0, 1));
+  EXPECT_FALSE(vers1.less_than(1, 0));
+  EXPECT_FALSE(vers1.less_than(1, 1));
+  EXPECT_TRUE(vers1.less_than(2, 0));
 }
 
 TEST(URDF_VERSION_CLASS, test_correct_string)

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -27,6 +27,7 @@
   <xs:complexType name="pose">
     <xs:attribute name="xyz" type="xs:string" default="0 0 0" />
     <xs:attribute name="rpy" type="xs:string" default="0 0 0" />
+    <xs:attribute name="quat_xyzw" type="xs:string" default="0 0 0 1" />
   </xs:complexType>
 
   <!-- pose node type -->

--- a/xsd/urdf.xsd
+++ b/xsd/urdf.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-   XML Schema for URDF v1.0
+   XML Schema for URDF v1.1
 
    This is a proposal XML Schema to validate the original URDF file
    format. It supports PR2 extensions (transmission) but not the
@@ -9,6 +9,7 @@
 
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   version="1.1"
 	   elementFormDefault="unqualified">
 
   <!-- data type definitions -->


### PR DESCRIPTION
This is a second attempt adding quaternions to the URDF spec from #194, which was reverted in #231 due to in order to properly handle schema versioning (see #230).

* https://github.com/ros/urdfdom/pull/235/commits/0c60c4968863f70aa0dfad15a6b24052edf4cb99: cherry-pick of #194 (with a minor whitespace fix)
* https://github.com/ros/urdfdom/pull/235/commits/783122f9acee202d658bfeb010a1f7b794e4967d: specify required version of urdfdom_headers in cmake find_package call
* https://github.com/ros/urdfdom/pull/235/commits/93dc23d5b6a56d71e8df13342ef384bfeae5aec3: updates the schema to indicate that version 1.1 is supported (more schema documentation / changelog needed)
* https://github.com/ros/urdfdom/pull/235/commits/23ccaff93b59b6e0e752ca2b925b5826698bc50e: adds comparison helpers to `URDFVersion` and updates the parsing logic to allow version 1.1
* https://github.com/ros/urdfdom/pull/235/commits/79e8067ccd63ca137a4a05b5c8990e6e4e22a021: pass URDFVersion object to link, joint, and other parsing functions
* https://github.com/ros/urdfdom/pull/235/commits/583cb8335388f87afee9a74acb45b4c28c690e8c: change `quat_xyzw` parsing logic based on URDFVersion and add tests

cc @saikishor