### PR TITLE
Read cmake version from package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 # Read version from package.xml
 file(READ package.xml PACKAGE_XML_DATA)
 string(REGEX MATCH "<version>([0-9]+)\.([0-9]+)\.([0-9]+)</version>" _ ${PACKAGE_XML_DATA})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,15 @@
 cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
-project (urdfdom CXX C)
-
-set (URDF_MAJOR_VERSION 5)
-set (URDF_MINOR_VERSION 0)
-set (URDF_PATCH_VERSION 4)
+# Read version from package.xml
+file(READ package.xml PACKAGE_XML_DATA)
+string(REGEX MATCH "<version>([0-9]+)\.([0-9]+)\.([0-9]+)</version>" _ ${PACKAGE_XML_DATA})
+set(URDF_MAJOR_VERSION ${CMAKE_MATCH_1})
+set(URDF_MINOR_VERSION ${CMAKE_MATCH_2})
+set(URDF_PATCH_VERSION ${CMAKE_MATCH_3})
 
 set (URDF_VERSION ${URDF_MAJOR_VERSION}.${URDF_MINOR_VERSION}.${URDF_PATCH_VERSION})
+project (urdfdom VERSION ${URDF_VERSION}
+                 LANGUAGES CXX C)
+
 set (URDF_MAJOR_MINOR_VERSION ${URDF_MAJOR_VERSION}.${URDF_MINOR_VERSION})
 
 message (STATUS "${PROJECT_NAME} version ${URDF_VERSION}")


### PR DESCRIPTION
Currently the package version is set in both package.xml and the CMakeLists.txt file and it's easy for them to get out of sync. This updates the cmake code to extract the version string from the package.xml file using a regular expression and passing it to the cmake `project()` call. This approach implements the suggestion by @clalancette in https://github.com/ros/urdfdom/pull/233#pullrequestreview-3562824096.

Alternative to #233 and #232.

cc @saikishor, @traversaro 