### PR TITLE
Fix ROS 2 CI workflow

### DIFF
--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -9,10 +9,12 @@ jobs:
 
   build_ros2:
     name: ROS 2 CI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v5
       - uses: ros-tooling/setup-ros@v0.7
         with:
+          use-ros2-testing: true
           required-ros-distributions: rolling
       - uses: ros-tooling/action-ros-ci@v0.4
         with:

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -15,7 +15,6 @@ jobs:
       - uses: ros-tooling/setup-ros@v0.7
         with:
           use-ros2-testing: true
-          required-ros-distributions: rolling
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: urdfdom


### PR DESCRIPTION
Use ubuntu-24.04, ros-testing, actions/checkout, and don't install rolling-desktop.