### PR TITLE
Prepare for 5.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,31 @@
 Changelog for package urdfdom
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+5.1.0 (2026-02-06)
+------------------
+* Support for URDF Specification 1.1
+    * Add support for capsule geometry type (`#238 <https://github.com/ros/urdfdom/issues/238>`_)
+      * Add documentation about versioning
+      * Require version 2.1.0 of urdfdom_headers
+      Co-authored-by: Steve Peters <scpeters@openrobotics.org>
+    * Support quaternions in URDF 1.1 (`#235 <https://github.com/ros/urdfdom/issues/235>`_)
+      Co-authored-by: Guillaume Doisy <doisyg@users.noreply.github.com>
+* Fix multiple format-string vulnerabilities in URDF parser logging (`#243 <https://github.com/ros/urdfdom/issues/243>`_)
+  User-controlled URDF content was passed directly to CONSOLE_BRIDGE_logError()
+  at multiple call sites, allowing printf-style format string interpretation.
+  All affected logging paths now use explicit "%s" format specifiers to ensure
+  input is treated as data and to prevent information disclosure or undefined
+  behavior.
+* More logging format string fixes (`#244 <https://github.com/ros/urdfdom/issues/244>`_)
+  * Add explicit "%s" format strings when logging
+  * Use %s format string instead of string addition
+* Read cmake version from package.xml (`#236 <https://github.com/ros/urdfdom/issues/236>`_)
+  * Use regex to match version string.
+  Based on suggestion from Chris Lalancette.
+  * Require cmake minimum version 3.10
+  Co-authored-by: Chris Lalancette <clalancette@gmail.com>
+* Contributors: Florencia, Sai Kishor Kothakota, Steve Peters
+
 5.0.4 (2025-12-08)
 ------------------
 * Revert "Quaternion in urdf (PR123 new attempt) (#231)" (`#231 <https://github.com/ros/urdfdom/issues/231>`_)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>urdfdom</name>
-  <version>5.0.4</version>
+  <version>5.1.0</version>
   <description>A library to access URDFs using the DOM model.</description>
 
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>


### PR DESCRIPTION
Opening a pull request for this to indicate my plan to release two backwards-compatible features to URDF version 1.1 with a minor version bump (5.1.0) of the urdfdom parser.

Part of the plan described in https://github.com/ros/urdfdom/issues/230#issuecomment-3821146503. I'll aim to make the release tomorrow.