### PR TITLE
Fix multiple format-string vulnerabilities in URDF parser logging

### DIFF
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -147,7 +147,7 @@ bool parseBox(Box &b, tinyxml2::XMLElement *c)
   catch (ParseError &e)
   {
     b.dim.clear();
-    CONSOLE_BRIDGE_logError(e.what());
+    CONSOLE_BRIDGE_logError("%s", e.what());
     return false;
   }
   return true;
@@ -170,7 +170,7 @@ bool parseCylinder(Cylinder &y, tinyxml2::XMLElement *c)
   } catch(std::runtime_error &) {
     std::stringstream stm;
     stm << "length [" << c->Attribute("length") << "] is not a valid float";
-    CONSOLE_BRIDGE_logError(stm.str().c_str());
+    CONSOLE_BRIDGE_logError("%s", stm.str().c_str());
     return false;
   }
 

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -55,7 +55,7 @@ ModelInterfaceSharedPtr  parseURDFFile(const std::string &path)
     std::ifstream stream( path.c_str() );
     if (!stream)
     {
-      CONSOLE_BRIDGE_logError(("File " + path + " does not exist").c_str());
+      CONSOLE_BRIDGE_logError("%s", ("File " + path + " does not exist").c_str());
       return ModelInterfaceSharedPtr();
     }
 

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -102,7 +102,7 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
         pose.position.init(xyz_str);
       }
       catch (ParseError &e) {
-        CONSOLE_BRIDGE_logError(e.what());
+        CONSOLE_BRIDGE_logError("%s", e.what());
         return false;
       }
     }
@@ -123,7 +123,7 @@ bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
         pose.rotation.init(rpy_str);
       }
       catch (ParseError &e) {
-        CONSOLE_BRIDGE_logError(e.what());
+        CONSOLE_BRIDGE_logError("%s", e.what());
         return false;
       }
     }


### PR DESCRIPTION
# Summary

This PR fixes several format-string issues in the URDF parser where user-controlled strings were passed directly to `CONSOLE_BRIDGE_logError()`. This allowed printf-style format specifiers in URDF input to be interpreted during error logging. 

This PR updates the affected locations to log user input using explicit `"%s"` format specifiers.

# Impact

If URDFs are loaded from untrusted sources and logs are observable, this could result in:
* Information disclosure (stack / heap / library addresses)
* Potential denial-of-service via malformed format expansion

No behavior change for valid URDFs.

# Proof of concept

URDF input containing format specifiers, ie:
```
<origin xyz="%p.%p.%p.%p.%p" rpy="0 0 0"/>
```

## Before fix

Error logs expand format specifiers and leak memory addresses:
```
root@b603ce3e7513:/home/urdfdom# ./reproduce
Error:   Unable to parse component [0x5e5ac8d06bb0.0x7fffba1d9aa0.(nil).(nil).(nil).(nil)] to a double (while parsing a vector value)
         at line 102 in /home/urdfdom/urdf_parser/src/pose.cpp
Error:   Could not parse visual element for Link [l]
         at line 453 in /home/urdfdom/urdf_parser/src/link.cpp
```

## After fix

Input is logged verbatim:
```
root@b603ce3e7513:/home/urdfdom# ./reproduce
Error:   Unable to parse component [%p.%p.%p.%p.%p.%p] to a double (while parsing a vector value)
         at line 102 in /home/urdfdom/urdf_parser/src/pose.cpp
Error:   Could not parse visual element for Link [l]
         at line 453 in /home/urdfdom/urdf_parser/src/link.cpp
```

---
The initial affected location was reported by @zeroone-kr (Wonil Jang). Additional instances were identified during follow-up analysis.