### PR TITLE
ROS 2 CI: build urdfdom_headers from source

### DIFF
--- a/.github/ci/urdfdom_headers_from_src.repos
+++ b/.github/ci/urdfdom_headers_from_src.repos
@@ -1,0 +1,5 @@
+repositories:
+  urdfdom_headers:
+    type: git
+    url: https://github.com/ros/urdfdom_headers.git
+    version: rolling

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -19,3 +19,4 @@ jobs:
         with:
           package-name: urdfdom
           target-ros2-distro: rolling
+          vcs-repo-file-url: .github/ci/urdfdom_headers_from_src.repos

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -8,8 +8,14 @@ on:
 jobs:
 
   build_ros2:
-    name: ROS 2 CI
+    name: 'ROS 2 CI (${{ matrix.build_name }})'
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - build_name: 'source deps'
+            vcs-repo-file-url: .github/ci/urdfdom_headers_from_src.repos
+          - build_name: 'released deps'
     steps:
       - uses: actions/checkout@v5
       - uses: ros-tooling/setup-ros@v0.7
@@ -19,4 +25,4 @@ jobs:
         with:
           package-name: urdfdom
           target-ros2-distro: rolling
-          vcs-repo-file-url: .github/ci/urdfdom_headers_from_src.repos
+          vcs-repo-file-url: ${{ matrix.vcs-repo-file-url }}

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -2,8 +2,12 @@
 name: urdfdom ROS 2 CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'rolling'
+      - 'ros2'
 
 jobs:
 


### PR DESCRIPTION
Currently the ROS 2 CI actions use the version of `urdfdom_headers` that has been released into the ROS Rolling testing repo. This adds a test matrix to the workflow to build against `urdfdom_headers` from source as well.

Also change the `push` rule to only run on special branches (`master`, `rolling`, `ros2`).

cc @christophebedard for review of this usage of action-ros-ci