### PR TITLE
Use URDF_MAJOR_VERSION for SOVERSION

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -22,7 +22,8 @@ macro(add_urdfdom_library)
   endif()
   set_target_properties(${add_urdfdom_library_LIBNAME} PROPERTIES
     DEFINE_SYMBOL URDFDOM_EXPORTS
-    SOVERSION ${URDF_MAJOR_VERSION})
+    SOVERSION ${URDF_MAJOR_VERSION}
+    VERSION ${URDF_VERSION})
 endmacro()
 
 if(TARGET console_bridge::console_bridge)

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -22,7 +22,7 @@ macro(add_urdfdom_library)
   endif()
   set_target_properties(${add_urdfdom_library_LIBNAME} PROPERTIES
     DEFINE_SYMBOL URDFDOM_EXPORTS
-    SOVERSION ${URDF_MAJOR_MINOR_VERSION})
+    SOVERSION ${URDF_MAJOR_VERSION})
 endmacro()
 
 if(TARGET console_bridge::console_bridge)


### PR DESCRIPTION
Related to https://github.com/ros/urdfdom/issues/220

Updated the `SOVERSION` property to use `${URDF_MAJOR_VERSION}` instead of `${URDF_MAJOR_MINOR_VERSION}` in the `add_urdfdom_library` macro in `urdf_parser/CMakeLists.txt`.

**Breaking change:**  beware that this is a potential breaking change for downstream consumers of the library so better done in a next major bump.