### PR TITLE
removed urdf_world/types.h deprecation

### DIFF
--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -46,7 +46,7 @@
 #include <urdf_model/color.h>
 #include <urdf_model/utils.h>
 #include <urdf_sensor/sensor.h>
-#include <urdf_world/types.h>
+#include <urdf_model/types.h>
 
 #include "exportdecl.h"
 


### PR DESCRIPTION
## Description

Related with this PR https://github.com/ros/urdfdom_headers/pull/99

There is a build warning https://ci.ros2.org/job/ci_linux/28574/clang-tidy/