### PR TITLE
Make parsePose() public again

### DIFF
--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -174,6 +174,9 @@ private:
 namespace urdf{
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDF(const std::string &xml_string);
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDFFile(const std::string &path);
+
+  URDFDOM_DLLAPI bool parsePose(Pose& pose, tinyxml2::XMLElement* element,
+                                const urdf_export_helpers::URDFVersion version);
 }
 
 #endif

--- a/urdf_parser/src/joint.cpp
+++ b/urdf_parser/src/joint.cpp
@@ -450,7 +450,7 @@ bool parseJoint(Joint &joint, tinyxml2::XMLElement* config,
   }
   else
   {
-    if (!parsePoseInternal(joint.parent_to_joint_origin_transform, origin_xml, version))
+    if (!parsePose(joint.parent_to_joint_origin_transform, origin_xml, version))
     {
       joint.parent_to_joint_origin_transform.clear();
       CONSOLE_BRIDGE_logError("Malformed parent origin element for joint [%s]", joint.name.c_str());

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -322,7 +322,7 @@ bool parseInertial(Inertial &i, tinyxml2::XMLElement *config,
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o)
   {
-    if (!parsePoseInternal(i.origin, o, version))
+    if (!parsePose(i.origin, o, version))
       return false;
   }
 
@@ -402,7 +402,7 @@ bool parseVisual(Visual &vis, tinyxml2::XMLElement *config,
   // Origin
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o) {
-    if (!parsePoseInternal(vis.origin, o, version))
+    if (!parsePose(vis.origin, o, version))
       return false;
   }
 
@@ -445,7 +445,7 @@ bool parseCollision(Collision &col, tinyxml2::XMLElement* config,
   // Origin
   tinyxml2::XMLElement *o = config->FirstChildElement("origin");
   if (o) {
-    if (!parsePoseInternal(col.origin, o, version))
+    if (!parsePose(col.origin, o, version))
       return false;
   }
 

--- a/urdf_parser/src/pose.cpp
+++ b/urdf_parser/src/pose.cpp
@@ -89,7 +89,7 @@ std::string values2str(double d)
 
 namespace urdf{
 
-bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
+bool parsePose(Pose &pose, tinyxml2::XMLElement* xml,
                        const urdf_export_helpers::URDFVersion version)
 {
   pose.clear();

--- a/urdf_parser/src/pose.hpp
+++ b/urdf_parser/src/pose.hpp
@@ -41,7 +41,7 @@
 
 namespace urdf {
 
-URDFDOM_DLLAPI bool parsePoseInternal(Pose &pose, tinyxml2::XMLElement* xml,
-                                      const urdf_export_helpers::URDFVersion version);
+URDFDOM_DLLAPI bool parsePose(Pose &pose, tinyxml2::XMLElement* xml,
+                              const urdf_export_helpers::URDFVersion version);
 
 }


### PR DESCRIPTION
`parsePose` is a very useful helper function that should be kept public.
Partially reverts 9a1f5b41acbb513051b23bf8a1d935bc2a1122cb
Fixes #245