### PR TITLE
ros2 CI: don't fail fast

### DIFF
--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -15,6 +15,7 @@ jobs:
     name: 'ROS 2 CI (${{ matrix.build_name }})'
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - build_name: 'source deps'


### PR DESCRIPTION
Set `fail-fast`=false to allow both types of builds to complete even if one fails first.

See https://github.com/ros/urdfdom/pull/248 for an example of a PR in which the `source deps` build was cancelled even though I believe it would have completed successfully.