### PR TITLE
Complete Capsule export support and add public exportURDF API

### DIFF
--- a/urdf_parser/include/urdf_parser/urdf_parser.h
+++ b/urdf_parser/include/urdf_parser/urdf_parser.h
@@ -174,6 +174,7 @@ private:
 namespace urdf{
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDF(const std::string &xml_string);
   URDFDOM_DLLAPI ModelInterfaceSharedPtr parseURDFFile(const std::string &path);
+  URDFDOM_DLLAPI std::string exportURDF(const ModelInterface &model);
 }
 
 #endif

--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -584,6 +584,15 @@ bool exportCylinder(Cylinder &y, tinyxml2::XMLElement *xml)
   return true;
 }
 
+bool exportCapsule(Capsule &c, tinyxml2::XMLElement *xml)
+{
+  tinyxml2::XMLElement *capsule_xml = xml->GetDocument()->NewElement("capsule");
+  capsule_xml->SetAttribute("radius", urdf_export_helpers::values2str(c.radius).c_str());
+  capsule_xml->SetAttribute("length", urdf_export_helpers::values2str(c.length).c_str());
+  xml->LinkEndChild(capsule_xml);
+  return true;
+}
+
 bool exportMesh(Mesh &m, tinyxml2::XMLElement *xml)
 {
   // e.g. add <mesh filename="my_file" scale="1 1 1"/>
@@ -613,6 +622,10 @@ bool exportGeometry(GeometrySharedPtr &geom, tinyxml2::XMLElement *xml)
   else if (urdf::dynamic_pointer_cast<Mesh>(geom))
   {
     exportMesh((*(urdf::dynamic_pointer_cast<Mesh>(geom).get())), geometry_xml);
+  }
+  else if (urdf::dynamic_pointer_cast<Capsule>(geom))
+  {
+    exportCapsule((*(urdf::dynamic_pointer_cast<Capsule>(geom).get())), geometry_xml);
   }
   else
   {

--- a/urdf_parser/src/model.cpp
+++ b/urdf_parser/src/model.cpp
@@ -289,6 +289,7 @@ tinyxml2::XMLDocument*  exportURDFInternal(const ModelInterface &model)
 
   tinyxml2::XMLElement* robot = doc->NewElement("robot");
   robot->SetAttribute("name", model.name_.c_str());
+  robot->SetAttribute("version", "1.2");
   doc->LinkEndChild(robot);
 
 
@@ -311,5 +312,14 @@ tinyxml2::XMLDocument*  exportURDFInternal(const ModelInterface &model)
   }
 
   return doc;
+}
+
+URDFDOM_DLLAPI std::string exportURDF(const ModelInterface &model)
+{
+  tinyxml2::XMLDocument *doc = exportURDFInternal(model);
+  tinyxml2::XMLPrinter printer;
+  doc->Print(&printer);
+  delete doc;
+  return printer.CStr();
 }
 }

--- a/urdf_parser/test/urdf_schema_capsule_geometry_test.cpp
+++ b/urdf_parser/test/urdf_schema_capsule_geometry_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <memory>
+#include <string>
 
 #include "urdf_model/link.h"
 #include "urdf_parser/urdf_parser.h"
@@ -264,6 +265,51 @@ TEST(URDF_UNIT_TEST, parse_multiple_capsules_in_same_link)
   ASSERT_NE(nullptr, collision_capsule_1);
   EXPECT_DOUBLE_EQ(0.2, collision_capsule_1->radius);
   EXPECT_DOUBLE_EQ(2.0, collision_capsule_1->length);
+}
+
+TEST(URDF_UNIT_TEST, export_capsule_geometry_round_trip)
+{
+  std::string urdf_str = R"urdf(
+    <robot name="capsule_export_test" version="1.1">
+      <link name="link1">
+        <visual>
+          <origin xyz="0.1 0.2 0.3" rpy="0 0 0"/>
+          <geometry>
+            <capsule radius="0.05" length="0.5"/>
+          </geometry>
+        </visual>
+        <collision>
+          <geometry>
+            <capsule radius="0.1" length="1.0"/>
+          </geometry>
+        </collision>
+      </link>
+    </robot>
+    )urdf";
+
+  urdf::ModelInterfaceSharedPtr model = urdf::parseURDF(urdf_str);
+  ASSERT_NE(nullptr, model);
+
+  std::string exported = urdf::exportURDF(*model);
+  ASSERT_FALSE(exported.empty());
+
+  urdf::ModelInterfaceSharedPtr reparsed = urdf::parseURDF(exported);
+  ASSERT_NE(nullptr, reparsed);
+
+  urdf::LinkConstSharedPtr link = reparsed->getLink("link1");
+  ASSERT_NE(nullptr, link);
+
+  ASSERT_EQ(1u, link->visual_array.size());
+  auto visual_capsule = std::dynamic_pointer_cast<urdf::Capsule>(link->visual_array[0]->geometry);
+  ASSERT_NE(nullptr, visual_capsule);
+  EXPECT_DOUBLE_EQ(0.05, visual_capsule->radius);
+  EXPECT_DOUBLE_EQ(0.5, visual_capsule->length);
+
+  ASSERT_EQ(1u, link->collision_array.size());
+  auto collision_capsule = std::dynamic_pointer_cast<urdf::Capsule>(link->collision_array[0]->geometry);
+  ASSERT_NE(nullptr, collision_capsule);
+  EXPECT_DOUBLE_EQ(0.1, collision_capsule->radius);
+  EXPECT_DOUBLE_EQ(1.0, collision_capsule->length);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
I was reviewing the changes of the Capsule geometry just in case before the official release, and I found that this geomtry is not exported anywhere. I added a utility here to finish that part