### PR TITLE
Update the minimum build version of the urdfdom_headers

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,14 +18,14 @@
   <build_depend>console_bridge_vendor</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>tinyxml2</build_depend>
-  <build_depend version_gte="0.2.3">urdfdom_headers</build_depend>
+  <build_depend version_gte="3.0.0">urdfdom_headers</build_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
 
   <exec_depend>console_bridge_vendor</exec_depend>
   <exec_depend>libconsole-bridge-dev</exec_depend>
   <exec_depend>tinyxml2</exec_depend>
-  <exec_depend version_gte="0.2.3">urdfdom_headers</exec_depend>
+  <exec_depend version_gte="3.0.0">urdfdom_headers</exec_depend>
 
   <test_depend>python3</test_depend>
 


### PR DESCRIPTION
As the new version of the urdfdom_headers has this new commit https://github.com/ros/urdfdom_headers/commit/17d5de5e0888f246c73ad68cf26c14f003c83e6f that adds the acceleration, deceleration, and jerk elements, and it wouldn't be built with the old version anyway, as we have the build_depend with version check, let's update it.